### PR TITLE
chore: remove VSCode configuration from git

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "rust-analyzer.rustfmt.extraArgs": [
-        "+nightly"
-    ],
-    "rust-analyzer.showUnlinkedFileNotification": false
-}


### PR DESCRIPTION
Let developers configure their VSCode without turning this into commit fests and battles of preferences.