### PR TITLE
schemadb: Remove API variability

### DIFF
--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -106,7 +106,7 @@ impl SchemaBatch {
 #[derive(Debug)]
 pub struct DB {
     name: String, // for logging
-    inner: rocksdb::DB,
+    inner: rocksdb::DBWithThreadMode<rocksdb::SingleThreaded>,
 }
 
 impl DB {


### PR DESCRIPTION
### Description

Use a rocksdb type that is not dependent on the features with which the crate is compiled, since some code in this crate uses API that's specific to a particular target type of the DB alias.

### Test Plan

Should unbreak the build in https://github.com/movementlabsxyz/movement/pull/34
