### PR TITLE
Make `LedgerInfo` the source of truth on revert

### DIFF
--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -212,20 +212,21 @@ impl DbWriter for AptosDB {
         let latest_version = self.get_latest_version()?;
         let target_version = ledger_info_with_sigs.ledger_info().version();
 
-        // Revert the ledger commit progress
         let ledger_batch = SchemaBatch::new();
+
+        // Revert the ledger commit progress
         ledger_batch.put::<DbMetadataSchema>(
             &DbMetadataKey::LedgerCommitProgress,
             &DbMetadataValue::Version(target_version),
         )?;
-        self.ledger_db.metadata_db().write_schemas(ledger_batch)?;
 
         // Revert the overall commit progress
-        let ledger_batch = SchemaBatch::new();
         ledger_batch.put::<DbMetadataSchema>(
             &DbMetadataKey::OverallCommitProgress,
             &DbMetadataValue::Version(target_version),
         )?;
+
+        // Write ledger metadata db changes
         self.ledger_db.metadata_db().write_schemas(ledger_batch)?;
 
         let temp_position = Position::from_postorder_index(latest_version)?;

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -586,7 +586,7 @@ pub trait DbWriter: Send + Sync {
         version_to_revert: Version,
         latest_version: Version,
         new_root_hash: HashValue,
-        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        ledger_info_with_sigs: &LedgerInfoWithSignatures,
     ) -> Result<()> {
         unimplemented!()
     }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -580,12 +580,9 @@ pub trait DbWriter: Send + Sync {
         unimplemented!()
     }
 
-    /// Revert a commit.
+    /// Revert to committed state referred to with the ledger information.
     fn revert_commit(
         &self,
-        version_to_revert: Version,
-        latest_version: Version,
-        new_root_hash: HashValue,
         ledger_info_with_sigs: &LedgerInfoWithSignatures,
     ) -> Result<()> {
         unimplemented!()


### PR DESCRIPTION
### Description

We need the up-to-version ledger info when reverting the database to a past commit,
all other information needed for reversion can be obtained either from this data structure
or from the database itself.

### Test Plan

Existing tests pass after modifications.