### PR TITLE
aptos-db: check commit lock when reverting

### DIFF
--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -21,9 +21,9 @@ impl DbWriter for AptosDB {
         sharded_state_cache: Option<&ShardedStateCache>,
     ) -> Result<()> {
         gauged_api("save_transactions", || {
-            // Executing and committing from more than one threads not allowed -- consensus and
-            // state sync must hand over to each other after all pending execution and committing
-            // complete.
+            // Executing, committing, or reverting from more than one threads not allowed --
+            // consensus and state sync must hand over to each other after all pending execution
+            // and committing complete.
             let _lock = self
                 .ledger_commit_lock
                 .try_lock()
@@ -208,6 +208,14 @@ impl DbWriter for AptosDB {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["revert_commit"])
             .start_timer();
+
+        // Executing, committing, or reverting from more than one threads not allowed --
+        // consensus and state sync must hand over to each other after all pending execution
+        // and committing complete.
+        let _lock = self
+            .ledger_commit_lock
+            .try_lock()
+            .expect("Concurrent committing detected.");
 
         let latest_version = self.get_latest_version()?;
         let target_version = ledger_info_with_sigs.ledger_info().version();


### PR DESCRIPTION
Acquire the same lock on `revert_commit` as on `save_transactions`, to ensure that no writers are working on the database concurrently.
