### PR TITLE
Cosmetic fixes to brand the CLI as Movement CLI

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Aptos CLI Changelog
+# Movement CLI Changelog
 
-All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+All notable changes to the Movement CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+Note, all changes listed before version 2.4.0 were for Aptos CLI, from which Movement CLI was derived.
 
 ## Unreleased
 - Updated CLI source compilation to use rust toolchain version 1.75.0 (from 1.74.1).

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -1,5 +1,5 @@
-# Aptos Command Line Interface (CLI) Tool
+# Movement Command Line Interface (CLI) Tool
 
-The `aptos` tool is a command line interface (CLI) for debugging, development, and node operation.
+The `movement` tool is a command line interface (CLI) for debugging, development, and node operation.
 
-See [Aptos CLI Documentation](https://aptos.dev/tools/aptos-cli/) for how to install the `aptos` CLI tool and how to use it.
+See [Movement CLI Documentation](https://docs.movementlabs.xyz) for how to install the `movement` CLI tool and how to use it.

--- a/crates/aptos/homebrew/README.md
+++ b/crates/aptos/homebrew/README.md
@@ -3,15 +3,14 @@
 Homebrew is a package manager that works for MacOS Silicon and Intel chips as well as Linux distributions like Debian
 and Ubuntu.
 
-The [Aptos command line interface (CLI)](https://aptos.dev/tools/aptos-cli/install-cli/) may be installed
-via [Homebrew](https://brew.sh/) for simplicity. This is an in-depth overview of Homebrew and the Aptos formula. In this
+The [Movement command line interface (CLI)](https://github.com/movementlabsxyz/aptos-core) may be installed
+via [Homebrew](https://brew.sh/) for simplicity. This is an in-depth overview of Homebrew and the Movement formula. In this
 guide, we go over each section of the Homebrew formula and steps to implement changes in the future.
 
 ## Quick guide
 
-- [Formula in Homebrew GitHub](https://github.com/Homebrew/homebrew-core/blob/master/Formula/aptos.rb)
-- [Aptos 1.0.3 New Formula PR for GitHub](https://github.com/Homebrew/homebrew-core/pull/119832)
-- [Aptos Formula Fix PR to use build_cli_release.sh](https://github.com/Homebrew/homebrew-core/pull/120051)
+- [Formula in Homebrew GitHub](https://github.com/Homebrew/homebrew-core/blob/master/Formula/movement.rb)
+- [Movement <version-number> New Formula PR for GitHub](<link-to-PR>)
 
 ## Getting started
 
@@ -27,29 +26,29 @@ brew help
 Once homebrew is installed, run
 
 ```bash
-brew install aptos
+brew install movement
 ```
 
 to test that it installed correctly, try
 
 ```bash
-aptos --help
+movement --help
 
 # This should return something like
 
-# aptos 1.0.5
-# Aptos Labs <opensource@aptoslabs.com>
-# Command Line Interface (CLI) for developing and interacting with the Aptos blockchain
+# movement 3.3.1
+# Movement Labs <email-addr>
+# Command Line Interface (CLI) for developing and interacting with the Movement network
 # ...
 ```
 
 ## Change guide
 
-Note: This guide is for developers who are trying to update the Aptos homebrew formula.
+Note: This guide is for developers who are trying to update the Movement homebrew formula.
 
 You can get the latest formula here: https://github.com/Homebrew/homebrew-core/blob/master/Formula/aptos.rb
 
-Copy the `aptos.rb` file to your `homebrew` `formula` directory. For example, on macOS with an M1, this will likely be:
+Copy the `movement.rb` file to your `homebrew` `formula` directory. For example, on macOS with an M1, this will likely be:
 
 ```bash
 /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula
@@ -57,7 +56,7 @@ Copy the `aptos.rb` file to your `homebrew` `formula` directory. For example, on
 
 ### Development
 
-After you've copied `aptos.rb` to your local `homebrew` `formula` directory, you can modify it and use the commands
+After you've copied `movement.rb` to your local `homebrew` `formula` directory, you can modify it and use the commands
 below for testing.
 
 ```bash
@@ -65,17 +64,17 @@ below for testing.
 /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula
 
 # Before submitting changes run
-brew audit --new-formula aptos      # For new formula
-brew audit aptos --strict --online
-brew install aptos
-brew test aptos
+brew audit --new-formula movement      # For new formula
+brew audit movement --strict --online
+brew install movement
+brew test movement
 
 # For debugging issues during the installation process you can do
-brew install aptos --interactive    # Interactive, gives you access to the shell
-brew install aptos -d               # Debug mode
+brew install movement --interactive    # Interactive, gives you access to the shell
+brew install movement -d               # Debug mode
 
 # Livecheck
-brew livecheck --debug aptos
+brew livecheck --debug movement
 ```
 
 ### Committing changes
@@ -92,11 +91,11 @@ Once you have audited and tested your brew formula using the commands above, mak
 ### Header
 
 ```ruby
-class Aptos < Formula
-  desc "Layer 1 blockchain built to support fair access to decentralized assets for all"
-  homepage "https://aptoslabs.com/"
-  url "https://github.com/aptos-labs/aptos-core/archive/refs/tags/aptos-cli-v1.0.3.tar.gz"
-  sha256 "670bb6cb841cb8a65294878af9a4f03d4cba2a598ab4550061fed3a4b1fe4e98"
+class Movement < Formula
+  desc "The first MoveVM Zk Layer 2 on Ethereum"
+  homepage "https://movementlabs.xyz"
+  url "<tarball-URL>"
+  sha256 "<checksum>"
   license "Apache-2.0"
   ...
 ```
@@ -152,7 +151,7 @@ discussion.
 To run livecheck for testing, we recommend including the `--debug` argument:
 
 ```bash
-brew livecheck --debug aptos
+brew livecheck --debug movement
 ```
 
 ### Depends on and installation
@@ -203,7 +202,7 @@ brew livecheck --debug aptos
 To conduct tests, run:
 
 ```bash
-brew test aptos
+brew test movement
 ```
 
 The current test generates a new key via the Aptos CLI and ensures the shell output matches the filename(s) for that

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -82,7 +82,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
             account
         } else {
             return Err(CliError::CommandArgumentError(
-                "Please provide an account using --account or run aptos init".to_string(),
+                "Please provide an account using --account or run movement init".to_string(),
             ));
         };
 

--- a/crates/aptos/src/update/tool.rs
+++ b/crates/aptos/src/update/tool.rs
@@ -20,7 +20,7 @@ use std::process::Command;
 #[derive(Debug, Parser)]
 pub struct UpdateTool {
     /// The owner of the repo to download the binary from.
-    #[clap(long, default_value = "aptos-labs")]
+    #[clap(long, default_value = "movementlabsxyz")]
     repo_owner: String,
 
     /// The name of the repo to download the binary from.
@@ -47,7 +47,7 @@ impl UpdateTool {
             },
             InstallationMethod::Homebrew => {
                 return Err(anyhow!(
-                    "Detected this CLI comes from homebrew, use `brew upgrade aptos` instead"
+                    "Detected this CLI comes from homebrew, use `brew upgrade movement` instead"
                 )
                 .into());
             },
@@ -107,7 +107,7 @@ impl UpdateTool {
         let config = Update::configure()
             .repo_owner(&self.repo_owner)
             .repo_name(&self.repo_name)
-            .bin_name("aptos")
+            .bin_name("movement")
             .current_version(cargo_crate_version!())
             .target_version_tag(&info.latest_version_tag)
             .target(target)
@@ -117,7 +117,7 @@ impl UpdateTool {
         // Update the binary.
         let result = config
             .update()
-            .map_err(|e| anyhow!("Failed to update Aptos CLI: {:#}", e))?;
+            .map_err(|e| anyhow!("Failed to update Movement CLI: {:#}", e))?;
 
         let message = match result {
             Status::UpToDate(_) => panic!("We should have caught this already"),
@@ -140,6 +140,6 @@ impl CliCommand<String> for UpdateTool {
     async fn execute(self) -> CliTypedResult<String> {
         tokio::task::spawn_blocking(move || self.update())
             .await
-            .context("Failed to self-update Aptos CLI")?
+            .context("Failed to self-update Movement CLI")?
     }
 }


### PR DESCRIPTION
## Description
Some cosmetic fixes to brand Aptos CLI as Movement CLI.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ x ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Visual review

## Key Areas to Review
One thing I'm unsure about is how to add Movement Labs copyright? 

For example the top of a file has

```python
# Copyright © Aptos Foundation
# SPDX-License-Identifier: Apache-2.0
```

I could add the Movement Labs copyright above it, like this:

```python
# Copyright © Movement Labs
# Copyright © Aptos Foundation
# SPDX-License-Identifier: Apache-2.0
```

Does that seem like a good way to do it?

## Checklist
- [x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x ] I have made corresponding changes to the documentation

