### PR TITLE
fix(vm-genesis): fix zero division, use the zero rewards rate instead

### DIFF
--- a/aptos-move/vm-genesis/Cargo.toml
+++ b/aptos-move/vm-genesis/Cargo.toml
@@ -36,4 +36,5 @@ proptest-derive = { workspace = true }
 
 [features]
 default = []
+aptos = [] # for excluding upstream code
 fuzzing = ["aptos-types/fuzzing", "move-core-types/fuzzing", "move-vm-types/fuzzing"]


### PR DESCRIPTION
Re-fix the zero divide (once done in #24 for the `suzuka` branch) on calculating the rewards rate on top of the recently synced Movement trunk.