### PR TITLE
Configure `movement init` to Movement devnet and testnet, remove mainnet for now

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -138,13 +138,13 @@ impl CliCommand<()> for InitTool {
             },
             Network::Testnet => {
                 profile_config.rest_url =
-                    Some("https://fullnode.testnet.aptoslabs.com".to_string());
+                    Some("https://aptos.testnet.suzuka.movementlabs.xyz/v1/".to_string());
                 profile_config.faucet_url =
-                    Some("https://faucet.testnet.aptoslabs.com".to_string());
+                    Some("https://faucet.testnet.suzuka.movementlabs.xyz/".to_string());
             },
             Network::Devnet => {
-                profile_config.rest_url = Some("https://fullnode.devnet.aptoslabs.com".to_string());
-                profile_config.faucet_url = Some("https://faucet.devnet.aptoslabs.com".to_string());
+                profile_config.rest_url = Some("https://aptos.devnet.inola.movementlabs.xyz/v1".to_string());
+                profile_config.faucet_url = Some("https://faucet.devnet.inola.movementlabs.xyz".to_string());
             },
             Network::Local => {
                 profile_config.rest_url = Some("http://localhost:8080".to_string());

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -114,7 +114,7 @@ impl CliCommand<()> for InitTool {
             network
         } else {
             eprintln!(
-                "Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]"
+                "Choose network from [devnet, testnet, local, custom | defaults to devnet]"
             );
             let input = read_line("network")?;
             let input = input.trim();
@@ -131,11 +131,11 @@ impl CliCommand<()> for InitTool {
 
         // Ensure that there is at least a REST URL set for the network
         match network {
-            Network::Mainnet => {
-                profile_config.rest_url =
-                    Some("https://fullnode.mainnet.aptoslabs.com".to_string());
-                profile_config.faucet_url = None;
-            },
+            // Network::Mainnet => {
+            //     profile_config.rest_url =
+            //         Some("https://fullnode.mainnet.aptoslabs.com".to_string());
+            //     profile_config.faucet_url = None;
+            // },
             Network::Testnet => {
                 profile_config.rest_url =
                     Some("https://aptos.testnet.suzuka.movementlabs.xyz/v1/".to_string());
@@ -328,9 +328,9 @@ impl CliCommand<()> for InitTool {
             }
         } else if account_exists {
             eprintln!("Account {} has been already found onchain", address);
-        } else if network == Network::Mainnet {
+        } /* else if network == Network::Mainnet {
             eprintln!("Account {} does not exist, you will need to create and fund the account by transferring funds from another account", address);
-        } else {
+        } */ else {
             eprintln!("Account {} has been initialized locally, but you must transfer coins to it to create the account onchain", address);
         }
 
@@ -440,7 +440,7 @@ impl InitTool {
 /// Any command using this, will be simpler to setup as profiles
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Network {
-    Mainnet,
+    // Mainnet,
     Testnet,
     Devnet,
     Local,
@@ -450,7 +450,7 @@ pub enum Network {
 impl Display for Network {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
-            Network::Mainnet => "mainnet",
+            // Network::Mainnet => "mainnet",
             Network::Testnet => "testnet",
             Network::Devnet => "devnet",
             Network::Local => "local",
@@ -464,14 +464,14 @@ impl FromStr for Network {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().trim() {
-            "mainnet" => Self::Mainnet,
+            // "mainnet" => Self::Mainnet,
             "testnet" => Self::Testnet,
             "devnet" => Self::Devnet,
             "local" => Self::Local,
             "custom" => Self::Custom,
             str => {
                 return Err(CliError::CommandArgumentError(format!(
-                    "Invalid network {}.  Must be one of [devnet, testnet, mainnet, local, custom]",
+                    "Invalid network {}.  Must be one of [devnet, testnet, local, custom]",
                     str
                 )));
             },

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -571,11 +571,11 @@ pub fn explorer_account_link(hash: AccountAddress, network: Option<Network>) -> 
     // For now, default to what the browser is already on, though the link could be wrong
     if let Some(network) = network {
         format!(
-            "https://explorer.aptoslabs.com/account/{}?network={}",
+            "https://explorer.movementlabs.xyz/account/{}?network={}",
             hash, network
         )
     } else {
-        format!("https://explorer.aptoslabs.com/account/{}", hash)
+        format!("https://explorer.movementlabs.xyz/account/{}", hash)
     }
 }
 
@@ -586,11 +586,11 @@ pub fn explorer_transaction_link(
     // For now, default to what the browser is already on, though the link could be wrong
     if let Some(network) = network {
         format!(
-            "https://explorer.aptoslabs.com/txn/{}?network={}",
+            "https://explorer.movementlabs.xyz/txn/{}?network={}",
             hash.to_hex_literal(),
             network
         )
     } else {
-        format!("https://explorer.aptoslabs.com/txn/{}", hash)
+        format!("https://explorer.movementlabs.xyz/txn/{}", hash)
     }
 }


### PR DESCRIPTION
## Description
CLI link fixes; needs review and final explorer links from @0xPrimata 

Also removed mainnet as a network option.

## Type of Change
- [ x] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ x ] Movement CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
I tested manually; explorer links are not finalized so this needs the final explorer links for Movement devnet and testnet.

## Key Areas to Review
Be sure that the RPC and faucet links are correct and that the way I commented out mainnet for now is acceptable.

## Checklist
- [ x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
