### PR TITLE
Configure cli-release.yaml for Movement

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,4 +1,4 @@
-# This defines a workflow to build and release a new version of the aptos CLI.
+# This defines a workflow to build and release a new version of the Movement CLI.
 # In order to trigger it go to the Actions Tab of the Repo, click "Release CLI" and then "Run Workflow".
 
 name: "Release CLI"
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      - uses: movementlabsxyz/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu"
       - name: Upload Binary
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      - uses: movementlabsxyz/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-22.04"
       - name: Upload Binary
@@ -94,23 +94,23 @@ jobs:
           files: |
             aptos-cli-*.zip
 
-  bump-homebrew-version-pr:
-    name: "Make PR to bump version in Homebrew"
-    needs:
-      - release-binaries
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
-        with:
-          formula-name: aptos
-          tag-name: "${{ format('aptos-cli-v{0}', inputs.release_version) }}"
-          base-branch: master
-          create-pullrequest: true
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Created by https://github.com/mislav/bump-homebrew-formula-action
-
-            From CLI release run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        env:
-          COMMITTER_TOKEN: ${{ secrets.APTOS_BOT_GH_PAT_APTOS_CORE_HOMEBREW_BUMPER }}
+#  bump-homebrew-version-pr:
+#    name: "Make PR to bump version in Homebrew"
+#    needs:
+#      - release-binaries
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: mislav/bump-homebrew-formula-action@v3
+#        with:
+#          formula-name: aptos
+#          tag-name: "${{ format('aptos-cli-v{0}', inputs.release_version) }}"
+#          base-branch: master
+#          create-pullrequest: true
+#          commit-message: |
+#            {{formulaName}} {{version}}
+#
+#            Created by https://github.com/mislav/bump-homebrew-formula-action
+#
+#            From CLI release run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#        env:
+#          COMMITTER_TOKEN: ${{ secrets.APTOS_BOT_GH_PAT_APTOS_CORE_HOMEBREW_BUMPER }}


### PR DESCRIPTION
## Description
Updated cli-release workflow to preparing to create Movement CLI release.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Not tested; someone with access to the repo's Actions can check whether the relevant actions are still present. Those require some inputs when manually triggering the workflow.

## Key Areas to Review

- Some tokens e.g. `secrets.GITHUB_TOKEN` may need to be configured.
- If Actions are not set up for the repo, we could configure using the flows in  `.github/actions`

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation