### PR TITLE
Fix: Recommend --skip-faucet flag on movement init with testnet and link to faucet after creating profile

### DIFF
--- a/.movement/config.yaml
+++ b/.movement/config.yaml
@@ -1,9 +1,0 @@
----
-profiles:
-  default:
-    network: Testnet
-    private_key: "0x533ec968be7481004693402410fc5d4a623a668218506c1443f3225fb2d10c2b"
-    public_key: "0x8980d4eebfd2ebd08e7a886bf6fcbb229767a1cc10a24eb2599322a1ef2a0152"
-    account: 0779feaacef83fcee0f6e4816c0ec8e1c46668aceced78b4469808ddf6809798
-    rest_url: "https://aptos.testnet.suzuka.movementlabs.xyz/v1/"
-    faucet_url: "https://faucet.testnet.suzuka.movementlabs.xyz/"

--- a/.movement/config.yaml
+++ b/.movement/config.yaml
@@ -1,0 +1,9 @@
+---
+profiles:
+  default:
+    network: Testnet
+    private_key: "0x533ec968be7481004693402410fc5d4a623a668218506c1443f3225fb2d10c2b"
+    public_key: "0x8980d4eebfd2ebd08e7a886bf6fcbb229767a1cc10a24eb2599322a1ef2a0152"
+    account: 0779feaacef83fcee0f6e4816c0ec8e1c46668aceced78b4469808ddf6809798
+    rest_url: "https://aptos.testnet.suzuka.movementlabs.xyz/v1/"
+    faucet_url: "https://faucet.testnet.suzuka.movementlabs.xyz/"

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -121,12 +121,14 @@ impl CliCommand<()> for InitTool {
             if input.is_empty() {
                 eprintln!("No network given, using devnet...");
                 Network::Devnet
-            } else if input.eq_ignore_ascii_case("testnet") && self.skip_faucet {
-                Network::Testnet
             } else {
                 Network::from_str(input)?
             }
         };
+
+        if network == Network::Testnet && !self.skip_faucet {
+            return Err("For testnet, start over and run movement init --skip-faucet");
+        }
 
         // Ensure the config contains the network used
         profile_config.network = Some(network);

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -121,6 +121,8 @@ impl CliCommand<()> for InitTool {
             if input.is_empty() {
                 eprintln!("No network given, using devnet...");
                 Network::Devnet
+            } else if input.eq_ignore_ascii_case("testnet") && self.skip_faucet {
+                Network::Testnet
             } else {
                 Network::from_str(input)?
             }
@@ -349,7 +351,9 @@ impl CliCommand<()> for InitTool {
             .profile_name()
             .unwrap_or(DEFAULT_PROFILE);
         eprintln!(
-            "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n Run `movement --help` for more information about commands",
+            "\n---\nMovement CLI is now set up for account {} as profile {}!\n See the account here: {}\n 
+            Run `movement --help` for more information about commands. \n 
+            Visit https://faucet.movementlabs.xyz to use the testnet faucet.",
             address,
             profile_name,
             explorer_account_link(address, Some(network))
@@ -465,7 +469,11 @@ impl FromStr for Network {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().trim() {
             // "mainnet" => Self::Mainnet,
-            "testnet" => Self::Testnet,
+            "testnet" => {
+                return Err(CliError::CommandArgumentError(format!(
+                    "To use testnet, run `movement init --skip-faucet`, follow the prompts to create an account address, then visit the faucet UI  at https://faucet.movementlabs.xyz to fund the account."
+                )));
+            },
             "devnet" => Self::Devnet,
             "local" => Self::Local,
             "custom" => Self::Custom,

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -114,7 +114,7 @@ impl CliCommand<()> for InitTool {
             network
         } else {
             eprintln!(
-                "Choose network from [devnet, testnet, local, custom | defaults to devnet]"
+                "Choose network from [devnet, testnet, local, custom | defaults to devnet]. For testnet, start over and run movement init --skip-faucet"
             );
             let input = read_line("network")?;
             let input = input.trim();
@@ -469,11 +469,7 @@ impl FromStr for Network {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().trim() {
             // "mainnet" => Self::Mainnet,
-            "testnet" => {
-                return Err(CliError::CommandArgumentError(format!(
-                    "To use testnet, run `movement init --skip-faucet`, follow the prompts to create an account address, then visit the faucet UI  at https://faucet.movementlabs.xyz to fund the account."
-                )));
-            },
+            "testnet" => Self::Testnet,
             "devnet" => Self::Devnet,
             "local" => Self::Local,
             "custom" => Self::Custom,


### PR DESCRIPTION
## Description
@Rahat-ch mentioned devs complaining about broken `movement init` process with testnet, that the lack of faucet access was making it so the Movement config file couldn't be created.

In this fix, `movement init` on testnet
- without `--skip-faucet` returns an error message recommending to use the flag in order to generate the Movement config.
- with `--skip-faucet` returns a success message linking users to the faucet UI.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
- Tested locally with CLI

## Key Areas to Review
- All changes are in `crates/aptos/src/common/init.rs`

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
