### PR TITLE
Remove panic in write_set_change grpc convertion

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
@@ -330,29 +330,32 @@ pub fn convert_write_set_change(change: &WriteSetChange) -> transaction::WriteSe
             )),
         },
         WriteSetChange::DeleteTableItem(delete_table_item) => {
-            let data = delete_table_item.data.as_ref().unwrap_or_else(|| {
-                panic!(
-                    "Could not extract data from DeletedTableItem '{:?}' with handle '{:?}'",
-                    delete_table_item,
-                    delete_table_item.handle.to_string()
-                )
-            });
+            let data = delete_table_item.data.as_ref();
+            // .unwrap_or_else(|| {
+            //     panic!(
+            //         "Could not extract data from DeletedTableItem '{:?}' with handle '{:?}'",
+            //         delete_table_item,
+            //         delete_table_item.handle.to_string()
+            //     )
+            // });
 
             transaction::WriteSetChange {
                 r#type: transaction::write_set_change::Type::DeleteTableItem as i32,
-                change: Some(transaction::write_set_change::Change::DeleteTableItem(
-                    transaction::DeleteTableItem {
-                        state_key_hash: convert_hex_string_to_bytes(
-                            &delete_table_item.state_key_hash,
-                        ),
-                        handle: delete_table_item.handle.to_string(),
-                        key: delete_table_item.key.to_string(),
-                        data: Some(transaction::DeleteTableData {
-                            key: data.key.to_string(),
-                            key_type: data.key_type.clone(),
-                        }),
-                    },
-                )),
+                change: data.map(|data| {
+                    transaction::write_set_change::Change::DeleteTableItem(
+                        transaction::DeleteTableItem {
+                            state_key_hash: convert_hex_string_to_bytes(
+                                &delete_table_item.state_key_hash,
+                            ),
+                            handle: delete_table_item.handle.to_string(),
+                            key: delete_table_item.key.to_string(),
+                            data: Some(transaction::DeleteTableData {
+                                key: data.key.to_string(),
+                                key_type: data.key_type.clone(),
+                            }),
+                        },
+                    )
+                }),
             }
         },
         WriteSetChange::WriteModule(write_module) => transaction::WriteSetChange {
@@ -374,10 +377,11 @@ pub fn convert_write_set_change(change: &WriteSetChange) -> transaction::WriteSe
                     r#type: Some(convert_move_struct_tag(&write_resource.data.typ)),
                     type_str: write_resource.data.typ.to_string(),
                     data: serde_json::to_string(&write_resource.data.data).unwrap_or_else(|_| {
-                        panic!(
-                            "Could not convert move_resource data to json '{:?}'",
-                            write_resource.data
-                        )
+                        "{}".to_string()
+                        // panic!(
+                        //     "Could not convert move_resource data to json '{:?}'",
+                        //     write_resource.data
+                        // )
                     }),
                 },
             )),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Remove the panic in the WriteSet change conversion for the indexer grpc stream. 
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Run the indexer test with movement branch.
## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
