### PR TITLE
Fix error return format in init.rs

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -127,7 +127,7 @@ impl CliCommand<()> for InitTool {
         };
 
         if network == Network::Testnet && !self.skip_faucet {
-            return Err(CliError::UnexpectedError(format!(
+            return Err(CliError::CommandArgumentError(format!(
                 "For testnet, start over and run movement init --skip-faucet"
             )));
         }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -127,7 +127,9 @@ impl CliCommand<()> for InitTool {
         };
 
         if network == Network::Testnet && !self.skip_faucet {
-            return Err("For testnet, start over and run movement init --skip-faucet");
+            return Err(CliError::UnexpectedError(format!(
+                "For testnet, start over and run movement init --skip-faucet"
+            )));
         }
 
         // Ensure the config contains the network used


### PR DESCRIPTION
We were returning `            return Err(
                "For testnet, start over and run movement init --skip-faucet");`

which compiled locally for me, but I noticed it caused CI to fail [this job](https://github.com/movementlabsxyz/movement/pull/506) with error

```
   Compiling aptos-node v0.0.0-main (/home/runner/actions-runner/_work/movement/movement/aptos-core/aptos-node)
error[E0308]: mismatched types
   --> crates/aptos/src/common/init.rs:130:24
    |
130 |             return Err("For testnet, start over and run movement init --skip-faucet");
    |                    --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `CliError`, found `&str`
    |                    |
    |                    arguments to this enum variant are incorrect
    |
help: the type constructed contains `&'static str` due to the type of the argument passed
   --> crates/aptos/src/common/init.rs:130:20
    |
130 |             return Err("For testnet, start over and run movement init --skip-faucet");
    |                    ^^^^-------------------------------------------------------------^
    |                        |
    |                        this argument influences the type of `Err`
```

It looks like we need to specify the arg type, hence this fix.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
