### PR TITLE
Feat: Add constant time lock durations to atomic bridge

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -1296,6 +1296,7 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
         nonce.inner = nonce.inner + 1;  // Safe <b>to</b> increment without overflow
     };
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce.inner));
+
     keccak256(combined_bytes)
 }
 </code></pre>
@@ -2419,6 +2420,7 @@ Completes a bridge transfer by revealing the pre-image.
     pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ) {
     <a href="atomic_bridge.md#0x1_bridge_configuration_assert_is_caller_operator">bridge_configuration::assert_is_caller_operator</a>(caller);
+
     <b>let</b> (recipient, amount) = <a href="atomic_bridge.md#0x1_bridge_store_complete_counterparty">bridge_store::complete_counterparty</a>(
         bridge_transfer_id,
         create_hashlock(pre_image)

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -366,6 +366,7 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     <a href="block.md#0x1_block_initialize">block::initialize</a>(&aptos_framework_account, epoch_interval_microsecs);
     <a href="state_storage.md#0x1_state_storage_initialize">state_storage::initialize</a>(&aptos_framework_account);
     <a href="timestamp.md#0x1_timestamp_set_time_has_started">timestamp::set_time_has_started</a>(&aptos_framework_account);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_initialize">atomic_bridge::initialize</a>(&aptos_framework_account);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -284,7 +284,6 @@ module aptos_framework::atomic_bridge_initiator {
 
         let recipient = valid_eip55();
         let hash_lock = valid_hash_lock();
-        let time_lock = 1000;
         let amount = 1000;
 
         initiate_bridge_transfer(
@@ -307,7 +306,6 @@ module aptos_framework::atomic_bridge_initiator {
 
         let recipient = valid_eip55();
         let hash_lock = valid_hash_lock();
-        let time_lock = 1000;
         let amount = 1000;
 
         let account_balance = amount + 1;
@@ -354,7 +352,6 @@ module aptos_framework::atomic_bridge_initiator {
 
         let recipient = valid_eip55();
         let hash_lock = valid_hash_lock();
-        let time_lock = 1000;
         let amount = 1000;
         let account_balance = amount + 1;
 
@@ -392,7 +389,6 @@ module aptos_framework::atomic_bridge_initiator {
 
         let recipient = valid_eip55();
         let hash_lock = valid_hash_lock();
-        let time_lock = 1000;
         let amount = 1000;
         let account_balance = amount + 1;
 
@@ -497,7 +493,6 @@ module aptos_framework::atomic_bridge_initiator {
 
         let recipient = valid_eip55();
         let hash_lock = valid_hash_lock();
-        let time_lock = 1000;
         let amount = 1000;
 
         let account_balance = amount + 1;
@@ -1291,7 +1286,6 @@ module aptos_framework::atomic_bridge_counterparty {
         let initiator = valid_eip55();
         let bridge_transfer_id = valid_bridge_transfer_id();
         let hash_lock = valid_hash_lock();
-        let time_lock = 1;
         let recipient = @0xcafe;
         let amount = 1;
 
@@ -1326,7 +1320,6 @@ module aptos_framework::atomic_bridge_counterparty {
         let initiator = valid_eip55();
         let bridge_transfer_id = valid_bridge_transfer_id();
         let hash_lock = valid_hash_lock();
-        let time_lock = 1;
         let recipient = @0xcafe;
         let amount = 1;
 


### PR DESCRIPTION
## Description
To enforce correct use of time as described in the [Atomic Bridge RFC](https://github.com/movementlabsxyz/rfcs/blob/7f3810e4c723474e19022583d124e40fcfdfd66d/0040-atomic-bridge/rfc-0040-atomic-bridge.md), the initiator time lock must be greater than the counterparty time lock.

The PR adds constant time lock durations of 48 hours for initiator and 24 hours for counterparty.   

Also fixed: 

- a bug where `create_details` was calling `create_time_lock` despite `create_time_lock` already being called, hence an extra call of `create_time_lock`. In fixing this I made the `initiate_bridge_transfer` and `lock_bridge_transfer_assets` functions create time lock and transfer details through the same flow, so the functions are more structurally consistent with each other.
- `genesis.md` doc needed `atomic_bridge::initialize` added to `initialize` function implementation.


## Type of Change
- [ x] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
All relevant tests have been updated. `aptos move test` passes.

## Key Areas to Review
- Ensure correct use of time locks given the fixed time lock durations.

## Checklist
- [x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x] I tested both happy and unhappy path of the functionality
- [ x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
