### PR TITLE
Patch log macros in db pruner to use tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "status-line",
+ "tracing",
 ]
 
 [[package]]

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -57,6 +57,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 static_assertions = { workspace = true }
 status-line = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 aptos-executor-types = { workspace = true }

--- a/storage/aptosdb/src/pruner/pruner_worker.rs
+++ b/storage/aptosdb/src/pruner/pruner_worker.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::pruner::db_pruner::DBPruner;
-use aptos_logger::{
-    error,
-    prelude::{sample, SampleRate},
-};
+use aptos_logger::prelude::{sample, SampleRate};
 use aptos_types::transaction::Version;
+
+use tracing::error;
+
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use anyhow::anyhow;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_jellyfish_merkle::{node_type::NodeKey, StaleNodeIndex};
-use aptos_logger::info;
+use tracing::info;
 use aptos_schemadb::{schema::KeyCodec, DB};
 use aptos_storage_interface::Result;
 use aptos_types::transaction::{AtomicVersion, Version};

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_shard_pruner.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_jellyfish_merkle::StaleNodeIndex;
-use aptos_logger::info;
+use tracing::info;
 use aptos_schemadb::{schema::KeyCodec, SchemaBatch, DB};
 use aptos_types::transaction::Version;
 use std::{marker::PhantomData, sync::Arc};


### PR DESCRIPTION
## Description

As we use tracing in Movement and aptos-logger does not integrate with that (rather, it wants to redirect the global tracing subscriber), selectively switch the few log event macros we are currently interested in observing to be emitted with tracing.

## How Has This Been Tested?

Will observe logs in an integration branch in movement.
