### PR TITLE
Atomic Bridge: Add `get_bridge_transfer_details` view function and fix duplicate `create_time_lock` calls

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -822,6 +822,20 @@ module aptos_framework::atomic_bridge_store {
         keccak256(combined_bytes)
     }
 
+    #[view]
+    public fun get_bridge_transfer_details(
+        bridge_transfer_id: vector<u8>
+    ): BridgeTransferDetails<address, EthereumAddress> acquires SmartTableWrapper {
+        let table = borrow_global<SmartTableWrapper<vector<u8>, BridgeTransferDetails<address, EthereumAddress>>>(@aptos_framework);
+
+        let details_ref = smart_table::borrow(
+            &table.inner,
+            bridge_transfer_id
+        );
+
+        *details_ref
+    }
+
     #[test_only]
     public fun valid_bridge_transfer_id() : vector<u8> {
         sha3_256(b"atomic bridge")
@@ -836,6 +850,58 @@ module aptos_framework::atomic_bridge_store {
     public fun valid_hash_lock() : vector<u8> {
         keccak256(plain_secret())
     }
+
+//#[test(aptos_framework = @aptos_framework, sender = @0xdaff)]
+//public fun test_get_bridge_transfer_details(
+//    sender: &signer,
+//    aptos_framework: &signer
+//) acquires SmartTableWrapper {
+//    let sender_address = signer::address_of(sender);
+//    
+//    let recipient_bytes = b"32Be343B94f860124dC4fEe278FDCBD38C102D88";
+//    let recipient = aptos_framework::ethereum::ethereum_address(recipient_bytes);
+//
+//    let amount = 1000;
+//    let hash_lock = aptos_framework::atomic_bridge_store::create_hashlock(b"hash_secret");
+//    let time_lock = aptos_framework::atomic_bridge_store::create_time_lock(1000);
+//    let bridge_transfer_id = b"12345678901234567890123456789012";
+//
+//    let details = aptos_framework::atomic_bridge_store::BridgeTransferDetails {
+//        addresses: aptos_framework::atomic_bridge_store::AddressPair {
+//            initiator: sender_address,
+//            recipient
+//        },
+//        amount,
+//        hash_lock,
+//        time_lock,
+//        state: PENDING_TRANSACTION
+//    };
+//
+//    add(bridge_transfer_id, details);
+//
+//    let retrieved_details = get_bridge_transfer_details(bridge_transfer_id);
+//
+//    // Fully destructure to consume all fields
+//    let aptos_framework::atomic_bridge_store::BridgeTransferDetails {
+//        addresses: aptos_framework::atomic_bridge_store::AddressPair {
+//            initiator: retrieved_initiator,
+//            recipient: retrieved_recipient,
+//        },
+//        amount: retrieved_amount,
+//        hash_lock: retrieved_hash_lock,
+//        time_lock: retrieved_time_lock,
+//        state: retrieved_state
+//    } = retrieved_details;
+//
+//    assert!(retrieved_initiator == sender_address, 0);
+//    assert!(retrieved_recipient == recipient, 0);
+//    assert!(retrieved_amount == amount, 0);
+//    assert!(retrieved_hash_lock == hash_lock, 0);
+//    assert!(retrieved_time_lock == time_lock, 0);
+//    assert!(retrieved_state == PENDING_TRANSACTION, 0);
+//
+//}
+
 }
 
 module aptos_framework::atomic_bridge_configuration {

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -823,10 +823,24 @@ module aptos_framework::atomic_bridge_store {
     }
 
     #[view]
-    public fun get_bridge_transfer_details(
+    public fun get_bridge_transfer_details_initiator(
         bridge_transfer_id: vector<u8>
     ): BridgeTransferDetails<address, EthereumAddress> acquires SmartTableWrapper {
         let table = borrow_global<SmartTableWrapper<vector<u8>, BridgeTransferDetails<address, EthereumAddress>>>(@aptos_framework);
+
+        let details_ref = smart_table::borrow(
+            &table.inner,
+            bridge_transfer_id
+        );
+
+        *details_ref
+    }
+
+    #[view]
+    public fun get_bridge_transfer_details_counterparty(
+        bridge_transfer_id: vector<u8>
+    ): BridgeTransferDetails<EthereumAddress, address> acquires SmartTableWrapper {
+        let table = borrow_global<SmartTableWrapper<vector<u8>, BridgeTransferDetails<EthereumAddress, address>>>(@aptos_framework);
 
         let details_ref = smart_table::borrow(
             &table.inner,

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -175,8 +175,7 @@ module aptos_framework::atomic_bridge_initiator {
     ) {
         let ethereum_address = ethereum::ethereum_address(recipient);
         let initiator_address = signer::address_of(initiator);
-        let time_lock = atomic_bridge_store::create_time_lock(
-            atomic_bridge_configuration::initiator_timelock_duration());
+        let time_lock = atomic_bridge_configuration::initiator_timelock_duration();
 
         let details =
             atomic_bridge_store::create_details(
@@ -1304,8 +1303,7 @@ module aptos_framework::atomic_bridge_counterparty {
     ) {
         atomic_bridge_configuration::assert_is_caller_operator(caller);
         let ethereum_address = ethereum::ethereum_address(initiator);
-        let time_lock = atomic_bridge_store::create_time_lock(
-            atomic_bridge_configuration::counterparty_timelock_duration());
+        let time_lock = atomic_bridge_configuration::counterparty_timelock_duration();
         let details = atomic_bridge_store::create_details(
             ethereum_address,
             recipient,


### PR DESCRIPTION
## Description
- Add `get_bridge_transfers_initiator` and `get_bridge_transfers_counterparty` view functions into `atomic_bridge_store` module with corresponding Move unit tests. All tests pass with `movement move test`
- Fix a bug where `create_time_lock` was called twice, resulting in time locks farther into the future than expected.

## Type of Change
- [ x] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
In `aptos-move/framework/aptos-framework/sources` run `movement move test` or `aptos move test`.

## Key Areas to Review

I think this works better as two separate functions because of the way it aligns with the `BridgeContract` trait in our Rust code. However, it could be possible to combine them into one function if someone wants to do that. For now this seems like a good solution to being able to fetch details without relying on event monitoring.

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x] I tested both happy and unhappy path of the functionality
- [ x] I have made corresponding changes to the documentation
