### PR TITLE
Remove EIP 55 check from `atomic_bridge_counterparty::lock_bridge_transfer_assets` and use `EventHandle` for events 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ test_indexer_grpc/*
 *.dot
 *.bytecode
 !third_party/move/move-prover/tests/xsources/design/*.bytecode
+
+# ignore boogie bpl
+boogie.bpl

--- a/aptos-move/e2e-move-tests/src/tests/bridge.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bridge.rs
@@ -206,7 +206,6 @@ fn test_initiator() {
     let events = harness.get_events();
     let bridge_transfer_initiated_event_tag = TypeTag::from_str("0x1::atomic_bridge_initiator::BridgeTransferInitiatedEvent").unwrap();
     let bridge_transfer_initiated_event = events.iter().find(|element| element.type_tag() == &bridge_transfer_initiated_event_tag).unwrap();
-    println!("Bridge transfer initiated event: {bridge_transfer_initiated_event:?}");
     let bridge_transfer_initiated_event = bcs::from_bytes::<BridgeTransferInitiatedEvent>(bridge_transfer_initiated_event.event_data()).unwrap();
     let bridge_transfer_id = bridge_transfer_initiated_event.bridge_transfer_id;
 

--- a/aptos-move/e2e-move-tests/src/tests/bridge.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bridge.rs
@@ -205,7 +205,8 @@ fn test_initiator() {
 
     let events = harness.get_events();
     let bridge_transfer_initiated_event_tag = TypeTag::from_str("0x1::atomic_bridge_initiator::BridgeTransferInitiatedEvent").unwrap();
-    let bridge_transfer_initiated_event = events.iter().find(|element| element.type_tag() == &bridge_transfer_initiated_event_tag).unwrap().v2().unwrap();
+    let bridge_transfer_initiated_event = events.iter().find(|element| element.type_tag() == &bridge_transfer_initiated_event_tag).unwrap();
+    println!("Bridge transfer initiated event: {bridge_transfer_initiated_event:?}");
     let bridge_transfer_initiated_event = bcs::from_bytes::<BridgeTransferInitiatedEvent>(bridge_transfer_initiated_event.event_data()).unwrap();
     let bridge_transfer_id = bridge_transfer_initiated_event.bridge_transfer_id;
 

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -1276,6 +1276,11 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
 
 ## Function `get_bridge_transfer_details_initiator`
 
+Gets initiator bridge transfer details given a bridge transfer ID
+
+@param bridge_transfer_id A 32-byte vector of unsigned 8-bit integers.
+@return A <code><a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a></code> struct.
+@abort If there is no transfer in the atomic bridge store.
 
 
 <pre><code>#[view]
@@ -1303,6 +1308,11 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
 
 ## Function `get_bridge_transfer_details_counterparty`
 
+Gets counterparty bridge transfer details given a bridge transfer ID
+
+@param bridge_transfer_id A 32-byte vector of unsigned 8-bit integers.
+@return A <code><a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a></code> struct.
+@abort If there is no transfer in the atomic bridge store.
 
 
 <pre><code>#[view]

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -2439,7 +2439,7 @@ Burns a specified amount of AptosCoin from an address.
 -  [Struct `BridgeTransferCompletedEvent`](#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent)
 -  [Struct `BridgeTransferCancelledEvent`](#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent)
 -  [Resource `BridgeCounterpartyEvents`](#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents)
--  [Function `init_module`](#0x1_atomic_bridge_counterparty_init_module)
+-  [Function `initialize`](#0x1_atomic_bridge_counterparty_initialize)
 -  [Function `lock_bridge_transfer_assets`](#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets)
 -  [Function `complete_bridge_transfer`](#0x1_atomic_bridge_counterparty_complete_bridge_transfer)
 -  [Function `abort_bridge_transfer`](#0x1_atomic_bridge_counterparty_abort_bridge_transfer)
@@ -2596,19 +2596,19 @@ This struct will store the event handles for bridge events.
 
 <dl>
 <dt>
-<code>bridge_transfer_locked: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">atomic_bridge_counterparty::BridgeTransferLockedEvent</a>&gt;</code>
+<code>bridge_transfer_locked_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">atomic_bridge_counterparty::BridgeTransferLockedEvent</a>&gt;</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>bridge_transfer_completed: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">atomic_bridge_counterparty::BridgeTransferCompletedEvent</a>&gt;</code>
+<code>bridge_transfer_completed_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">atomic_bridge_counterparty::BridgeTransferCompletedEvent</a>&gt;</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>bridge_transfer_cancelled: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">atomic_bridge_counterparty::BridgeTransferCancelledEvent</a>&gt;</code>
+<code>bridge_transfer_cancelled_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">atomic_bridge_counterparty::BridgeTransferCancelledEvent</a>&gt;</code>
 </dt>
 <dd>
 
@@ -2618,14 +2618,14 @@ This struct will store the event handles for bridge events.
 
 </details>
 
-<a id="0x1_atomic_bridge_counterparty_init_module"></a>
+<a id="0x1_atomic_bridge_counterparty_initialize"></a>
 
-## Function `init_module`
+## Function `initialize`
 
 Initializes the module and stores the <code>EventHandle</code>s in the resource.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -2634,11 +2634,11 @@ Initializes the module and stores the <code>EventHandle</code>s in the resource.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
-        bridge_transfer_locked: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">BridgeTransferLockedEvent</a>&gt;(aptos_framework),
-        bridge_transfer_completed: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
-        bridge_transfer_cancelled: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">BridgeTransferCancelledEvent</a>&gt;(aptos_framework),
+        bridge_transfer_locked_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">BridgeTransferLockedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_completed_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_cancelled_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">BridgeTransferCancelledEvent</a>&gt;(aptos_framework),
     });
 }
 </code></pre>
@@ -2697,7 +2697,7 @@ Locks assets for a bridge transfer by the initiator.
     <b>let</b> bridge_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
 
     <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_events.bridge_transfer_locked,
+        &<b>mut</b> bridge_events.bridge_transfer_locked_events,
         <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">BridgeTransferLockedEvent</a> {
             bridge_transfer_id,
             initiator,
@@ -2748,7 +2748,7 @@ Completes a bridge transfer by revealing the pre-image.
 
     <b>let</b> bridge_counterparty_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
     <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_counterparty_events.bridge_transfer_completed,
+        &<b>mut</b> bridge_counterparty_events.bridge_transfer_completed_events,
         <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a> {
             bridge_transfer_id,
             pre_image,
@@ -2791,7 +2791,7 @@ Aborts a bridge transfer if the time lock has expired.
 
     <b>let</b> bridge_counterparty_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
     <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_counterparty_events.bridge_transfer_cancelled,
+        &<b>mut</b> bridge_counterparty_events.bridge_transfer_cancelled_events,
         <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">BridgeTransferCancelledEvent</a> {
             bridge_transfer_id,
         },
@@ -2815,7 +2815,7 @@ Aborts a bridge transfer if the time lock has expired.
 -  [Struct `BridgeTransferCompletedEvent`](#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent)
 -  [Struct `BridgeTransferRefundedEvent`](#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent)
 -  [Resource `BridgeInitiatorEvents`](#0x1_atomic_bridge_initiator_BridgeInitiatorEvents)
--  [Function `init_module`](#0x1_atomic_bridge_initiator_init_module)
+-  [Function `initialize`](#0x1_atomic_bridge_initiator_initialize)
 -  [Function `initiate_bridge_transfer`](#0x1_atomic_bridge_initiator_initiate_bridge_transfer)
 -  [Function `complete_bridge_transfer`](#0x1_atomic_bridge_initiator_complete_bridge_transfer)
 -  [Function `refund_bridge_transfer`](#0x1_atomic_bridge_initiator_refund_bridge_transfer)
@@ -2970,19 +2970,19 @@ This struct will store the event handles for bridge events.
 
 <dl>
 <dt>
-<code>bridge_transfer_initiated: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">atomic_bridge_initiator::BridgeTransferInitiatedEvent</a>&gt;</code>
+<code>bridge_transfer_initiated_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">atomic_bridge_initiator::BridgeTransferInitiatedEvent</a>&gt;</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>bridge_transfer_completed: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">atomic_bridge_initiator::BridgeTransferCompletedEvent</a>&gt;</code>
+<code>bridge_transfer_completed_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">atomic_bridge_initiator::BridgeTransferCompletedEvent</a>&gt;</code>
 </dt>
 <dd>
 
 </dd>
 <dt>
-<code>bridge_transfer_refunded: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">atomic_bridge_initiator::BridgeTransferRefundedEvent</a>&gt;</code>
+<code>bridge_transfer_refunded_events: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">atomic_bridge_initiator::BridgeTransferRefundedEvent</a>&gt;</code>
 </dt>
 <dd>
 
@@ -2992,14 +2992,14 @@ This struct will store the event handles for bridge events.
 
 </details>
 
-<a id="0x1_atomic_bridge_initiator_init_module"></a>
+<a id="0x1_atomic_bridge_initiator_initialize"></a>
 
-## Function `init_module`
+## Function `initialize`
 
 Initializes the module and stores the <code>EventHandle</code>s in the resource.
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
 </code></pre>
 
 
@@ -3008,11 +3008,11 @@ Initializes the module and stores the <code>EventHandle</code>s in the resource.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
-        bridge_transfer_initiated: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a>&gt;(aptos_framework),
-        bridge_transfer_completed: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
-        bridge_transfer_refunded: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">BridgeTransferRefundedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_initiated_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_completed_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_refunded_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">BridgeTransferRefundedEvent</a>&gt;(aptos_framework),
     });
 }
 </code></pre>
@@ -3063,7 +3063,7 @@ The amount is burnt from the initiator
 
     <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
     <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_initiator_events.bridge_transfer_initiated,
+        &<b>mut</b> bridge_initiator_events.bridge_transfer_initiated_events,
         <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a> {
             bridge_transfer_id,
             initiator: initiator_address,
@@ -3106,7 +3106,7 @@ Bridge operator can complete the transfer
 
     <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
     <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_initiator_events.bridge_transfer_completed,
+        &<b>mut</b> bridge_initiator_events.bridge_transfer_completed_events,
         <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a> {
             bridge_transfer_id,
             pre_image,
@@ -3144,7 +3144,7 @@ Anyone can refund the transfer on the source chain once time lock has passed
 
     <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
     <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
-        &<b>mut</b> bridge_initiator_events.bridge_transfer_refunded,
+        &<b>mut</b> bridge_initiator_events.bridge_transfer_refunded_events,
         <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">BridgeTransferRefundedEvent</a> {
             bridge_transfer_id,
         },

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -1881,7 +1881,8 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_update_bridge_operator">update_bridge_operator</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_update_bridge_operator">update_bridge_operator</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>
+)   <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>let</b> bridge_config = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework);
     <b>let</b> old_operator = bridge_config.bridge_operator;
@@ -1917,7 +1918,8 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_initiator_time_lock_duration">set_initiator_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_initiator_time_lock_duration">set_initiator_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).initiator_time_lock = time_lock;
 
@@ -1948,7 +1950,8 @@ Updates the bridge operator, requiring governance validation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_counterparty_time_lock_duration">set_counterparty_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_set_counterparty_time_lock_duration">set_counterparty_time_lock_duration</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, time_lock: u64
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).counterparty_time_lock = time_lock;
 
@@ -2061,7 +2064,8 @@ Asserts that the caller is the current bridge operator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">assert_is_caller_operator</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">assert_is_caller_operator</a>(caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a> {
     <b>assert</b>!(<b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_configuration_BridgeConfig">BridgeConfig</a>&gt;(@aptos_framework).bridge_operator == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(caller), <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_EINVALID_BRIDGE_OPERATOR">EINVALID_BRIDGE_OPERATOR</a>);
 }
 </code></pre>
@@ -2434,12 +2438,15 @@ Burns a specified amount of AptosCoin from an address.
 -  [Struct `BridgeTransferLockedEvent`](#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent)
 -  [Struct `BridgeTransferCompletedEvent`](#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent)
 -  [Struct `BridgeTransferCancelledEvent`](#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent)
+-  [Resource `BridgeCounterpartyEvents`](#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents)
+-  [Function `init_module`](#0x1_atomic_bridge_counterparty_init_module)
 -  [Function `lock_bridge_transfer_assets`](#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets)
 -  [Function `complete_bridge_transfer`](#0x1_atomic_bridge_counterparty_complete_bridge_transfer)
 -  [Function `abort_bridge_transfer`](#0x1_atomic_bridge_counterparty_abort_bridge_transfer)
 
 
-<pre><code><b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge">0x1::atomic_bridge</a>;
+<pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
+<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge">0x1::atomic_bridge</a>;
 <b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration">0x1::atomic_bridge_configuration</a>;
 <b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store">0x1::atomic_bridge_store</a>;
 <b>use</b> <a href="atomic_bridge.md#0x1_ethereum">0x1::ethereum</a>;
@@ -2571,6 +2578,75 @@ An event triggered upon cancelling a bridge transfer
 
 </details>
 
+<a id="0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents"></a>
+
+## Resource `BridgeCounterpartyEvents`
+
+This struct will store the event handles for bridge events.
+
+
+<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bridge_transfer_locked: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">atomic_bridge_counterparty::BridgeTransferLockedEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>bridge_transfer_completed: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">atomic_bridge_counterparty::BridgeTransferCompletedEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>bridge_transfer_cancelled: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">atomic_bridge_counterparty::BridgeTransferCancelledEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_atomic_bridge_counterparty_init_module"></a>
+
+## Function `init_module`
+
+Initializes the module and stores the <code>EventHandle</code>s in the resource.
+
+
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
+        bridge_transfer_locked: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">BridgeTransferLockedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_completed: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_cancelled: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">BridgeTransferCancelledEvent</a>&gt;(aptos_framework),
+    });
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets"></a>
 
 ## Function `lock_bridge_transfer_assets`
@@ -2596,14 +2672,14 @@ Locks assets for a bridge transfer by the initiator.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets">lock_bridge_transfer_assets</a>(
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_lock_bridge_transfer_assets">lock_bridge_transfer_assets</a> (
     caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     initiator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     recipient: <b>address</b>,
     amount: u64
-) {
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
     <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">atomic_bridge_configuration::assert_is_caller_operator</a>(caller);
     <b>let</b> ethereum_address = <a href="atomic_bridge.md#0x1_ethereum_ethereum_address_no_eip55">ethereum::ethereum_address_no_eip55</a>(initiator);
     <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_counterparty_timelock_duration">atomic_bridge_configuration::counterparty_timelock_duration</a>();
@@ -2618,7 +2694,10 @@ Locks assets for a bridge transfer by the initiator.
     // bridge_store::add_counterparty(bridge_transfer_id, details);
     <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">atomic_bridge_store::add</a>(bridge_transfer_id, details);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(
+    <b>let</b> bridge_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
+
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> bridge_events.bridge_transfer_locked,
         <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferLockedEvent">BridgeTransferLockedEvent</a> {
             bridge_transfer_id,
             initiator,
@@ -2655,10 +2734,10 @@ Completes a bridge transfer by revealing the pre-image.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_complete_bridge_transfer">complete_bridge_transfer</a>(
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_complete_bridge_transfer">complete_bridge_transfer</a> (
     bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-) {
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
     <b>let</b> (recipient, amount) = <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">atomic_bridge_store::complete_transfer</a>&lt;EthereumAddress, <b>address</b>&gt;(
         bridge_transfer_id,
         create_hashlock(pre_image)
@@ -2667,7 +2746,9 @@ Completes a bridge transfer by revealing the pre-image.
     // Mint, fails silently
     <a href="atomic_bridge.md#0x1_atomic_bridge_mint">atomic_bridge::mint</a>(recipient, amount);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(
+    <b>let</b> bridge_counterparty_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> bridge_counterparty_events.bridge_transfer_completed,
         <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a> {
             bridge_transfer_id,
             pre_image,
@@ -2700,15 +2781,17 @@ Aborts a bridge transfer if the time lock has expired.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_abort_bridge_transfer">abort_bridge_transfer</a>(
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_abort_bridge_transfer">abort_bridge_transfer</a> (
     caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-) {
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a> {
     <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">atomic_bridge_configuration::assert_is_caller_operator</a>(caller);
 
     <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">atomic_bridge_store::cancel_transfer</a>&lt;EthereumAddress, <b>address</b>&gt;(bridge_transfer_id);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(
+    <b>let</b> bridge_counterparty_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeCounterpartyEvents">BridgeCounterpartyEvents</a>&gt;(@aptos_framework);
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> bridge_counterparty_events.bridge_transfer_cancelled,
         <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_BridgeTransferCancelledEvent">BridgeTransferCancelledEvent</a> {
             bridge_transfer_id,
         },
@@ -2731,12 +2814,15 @@ Aborts a bridge transfer if the time lock has expired.
 -  [Struct `BridgeTransferInitiatedEvent`](#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent)
 -  [Struct `BridgeTransferCompletedEvent`](#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent)
 -  [Struct `BridgeTransferRefundedEvent`](#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent)
+-  [Resource `BridgeInitiatorEvents`](#0x1_atomic_bridge_initiator_BridgeInitiatorEvents)
+-  [Function `init_module`](#0x1_atomic_bridge_initiator_init_module)
 -  [Function `initiate_bridge_transfer`](#0x1_atomic_bridge_initiator_initiate_bridge_transfer)
 -  [Function `complete_bridge_transfer`](#0x1_atomic_bridge_initiator_complete_bridge_transfer)
 -  [Function `refund_bridge_transfer`](#0x1_atomic_bridge_initiator_refund_bridge_transfer)
 
 
-<pre><code><b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge">0x1::atomic_bridge</a>;
+<pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
+<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge">0x1::atomic_bridge</a>;
 <b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_configuration">0x1::atomic_bridge_configuration</a>;
 <b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store">0x1::atomic_bridge_store</a>;
 <b>use</b> <a href="atomic_bridge.md#0x1_ethereum">0x1::ethereum</a>;
@@ -2866,6 +2952,75 @@ Aborts a bridge transfer if the time lock has expired.
 
 </details>
 
+<a id="0x1_atomic_bridge_initiator_BridgeInitiatorEvents"></a>
+
+## Resource `BridgeInitiatorEvents`
+
+This struct will store the event handles for bridge events.
+
+
+<pre><code><b>struct</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> <b>has</b> store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bridge_transfer_initiated: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">atomic_bridge_initiator::BridgeTransferInitiatedEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>bridge_transfer_completed: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">atomic_bridge_initiator::BridgeTransferCompletedEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>bridge_transfer_refunded: <a href="event.md#0x1_event_EventHandle">event::EventHandle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">atomic_bridge_initiator::BridgeTransferRefundedEvent</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_atomic_bridge_initiator_init_module"></a>
+
+## Function `init_module`
+
+Initializes the module and stores the <code>EventHandle</code>s in the resource.
+
+
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_init_module">init_module</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <b>move_to</b>(aptos_framework, <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
+        bridge_transfer_initiated: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_completed: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a>&gt;(aptos_framework),
+        bridge_transfer_refunded: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">BridgeTransferRefundedEvent</a>&gt;(aptos_framework),
+    });
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_atomic_bridge_initiator_initiate_bridge_transfer"></a>
 
 ## Function `initiate_bridge_transfer`
@@ -2889,7 +3044,7 @@ The amount is burnt from the initiator
     recipient: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     hash_lock: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     amount: u64
-) {
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
     <b>let</b> ethereum_address = <a href="atomic_bridge.md#0x1_ethereum_ethereum_address">ethereum::ethereum_address</a>(recipient);
     <b>let</b> initiator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(initiator);
     <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initiator_timelock_duration">atomic_bridge_configuration::initiator_timelock_duration</a>();
@@ -2906,7 +3061,9 @@ The amount is burnt from the initiator
     <a href="atomic_bridge.md#0x1_atomic_bridge_store_add">atomic_bridge_store::add</a>(bridge_transfer_id, details);
     <a href="atomic_bridge.md#0x1_atomic_bridge_burn">atomic_bridge::burn</a>(initiator_address, amount);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(
+    <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> bridge_initiator_events.bridge_transfer_initiated,
         <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferInitiatedEvent">BridgeTransferInitiatedEvent</a> {
             bridge_transfer_id,
             initiator: initiator_address,
@@ -2939,15 +3096,17 @@ Bridge operator can complete the transfer
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a>(
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_complete_bridge_transfer">complete_bridge_transfer</a> (
     caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     pre_image: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-) {
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
     assert_is_caller_operator(caller);
     <b>let</b> (_, _) = <a href="atomic_bridge.md#0x1_atomic_bridge_store_complete_transfer">atomic_bridge_store::complete_transfer</a>&lt;<b>address</b>, EthereumAddress&gt;(bridge_transfer_id, create_hashlock(pre_image));
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(
+    <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> bridge_initiator_events.bridge_transfer_completed,
         <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferCompletedEvent">BridgeTransferCompletedEvent</a> {
             bridge_transfer_id,
             pre_image,
@@ -2976,14 +3135,16 @@ Anyone can refund the transfer on the source chain once time lock has passed
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_refund_bridge_transfer">refund_bridge_transfer</a>(
+<pre><code><b>public</b> entry <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_refund_bridge_transfer">refund_bridge_transfer</a> (
     _caller: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-) {
+) <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a> {
     <b>let</b> (receiver, amount) = <a href="atomic_bridge.md#0x1_atomic_bridge_store_cancel_transfer">atomic_bridge_store::cancel_transfer</a>&lt;<b>address</b>, EthereumAddress&gt;(bridge_transfer_id);
     <a href="atomic_bridge.md#0x1_atomic_bridge_mint">atomic_bridge::mint</a>(receiver, amount);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(
+    <b>let</b> bridge_initiator_events = <b>borrow_global_mut</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeInitiatorEvents">BridgeInitiatorEvents</a>&gt;(@aptos_framework);
+    <a href="event.md#0x1_event_emit_event">event::emit_event</a>(
+        &<b>mut</b> bridge_initiator_events.bridge_transfer_refunded,
         <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_BridgeTransferRefundedEvent">BridgeTransferRefundedEvent</a> {
             bridge_transfer_id,
         },

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -10,6 +10,7 @@
 -  [Function `ethereum_address`](#0x1_ethereum_ethereum_address)
 -  [Function `to_lowercase`](#0x1_ethereum_to_lowercase)
 -  [Function `to_eip55_checksumed_address`](#0x1_ethereum_to_eip55_checksumed_address)
+-  [Function `get_inner`](#0x1_ethereum_get_inner)
 -  [Function `assert_eip55`](#0x1_ethereum_assert_eip55)
 
 
@@ -205,6 +206,30 @@ Converts an Ethereum address to EIP-55 checksummed format.
 
 </details>
 
+<a id="0x1_ethereum_get_inner"></a>
+
+## Function `get_inner`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_get_inner">get_inner</a>(eth_address: &<a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_get_inner">get_inner</a>(eth_address: &<a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    eth_address.inner
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_ethereum_assert_eip55"></a>
 
 ## Function `assert_eip55`
@@ -271,6 +296,9 @@ Checks if an Ethereum address conforms to the EIP-55 checksum standard.
 -  [Function `cancel_details`](#0x1_atomic_bridge_store_cancel_details)
 -  [Function `cancel_transfer`](#0x1_atomic_bridge_store_cancel_transfer)
 -  [Function `bridge_transfer_id`](#0x1_atomic_bridge_store_bridge_transfer_id)
+-  [Function `get_bridge_transfer_details_initiator`](#0x1_atomic_bridge_store_get_bridge_transfer_details_initiator)
+-  [Function `get_bridge_transfer_details_counterparty`](#0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty)
+-  [Function `get_bridge_transfer_details`](#0x1_atomic_bridge_store_get_bridge_transfer_details)
 -  [Specification](#@Specification_1)
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `create_time_lock`](#@Specification_1_create_time_lock)
@@ -1207,6 +1235,92 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce.inner));
 
     keccak256(combined_bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_atomic_bridge_store_get_bridge_transfer_details_initiator"></a>
+
+## Function `get_bridge_transfer_details_initiator`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_initiator">get_bridge_transfer_details_initiator</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;<b>address</b>, <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_initiator">get_bridge_transfer_details_initiator</a>(
+    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;<b>address</b>, EthereumAddress&gt; <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>(bridge_transfer_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty"></a>
+
+## Function `get_bridge_transfer_details_counterparty`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty">get_bridge_transfer_details_counterparty</a>(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;<a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>, <b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details_counterparty">get_bridge_transfer_details_counterparty</a>(
+    bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;EthereumAddress, <b>address</b>&gt; <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
+    <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>(bridge_transfer_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_atomic_bridge_store_get_bridge_transfer_details"></a>
+
+## Function `get_bridge_transfer_details`
+
+
+
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>&lt;Initiator: <b>copy</b>, store, Recipient: <b>copy</b>, store&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">atomic_bridge_store::BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_get_bridge_transfer_details">get_bridge_transfer_details</a>&lt;Initiator: store + <b>copy</b>, Recipient: store + <b>copy</b>&gt;(bridge_transfer_id: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt; <b>acquires</b> <a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a> {
+    <b>let</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a> = <b>borrow_global</b>&lt;<a href="atomic_bridge.md#0x1_atomic_bridge_store_SmartTableWrapper">SmartTableWrapper</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="atomic_bridge.md#0x1_atomic_bridge_store_BridgeTransferDetails">BridgeTransferDetails</a>&lt;Initiator, Recipient&gt;&gt;&gt;(@aptos_framework);
+
+    <b>let</b> details_ref = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow">smart_table::borrow</a>(
+        &<a href="../../aptos-stdlib/doc/table.md#0x1_table">table</a>.inner,
+        bridge_transfer_id
+    );
+
+    *details_ref
 }
 </code></pre>
 
@@ -2462,8 +2576,7 @@ Locks assets for a bridge transfer by the initiator.
 ) {
     <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">atomic_bridge_configuration::assert_is_caller_operator</a>(caller);
     <b>let</b> ethereum_address = <a href="atomic_bridge.md#0x1_ethereum_ethereum_address">ethereum::ethereum_address</a>(initiator);
-    <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">atomic_bridge_store::create_time_lock</a>(
-        <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_counterparty_timelock_duration">atomic_bridge_configuration::counterparty_timelock_duration</a>());
+    <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_counterparty_timelock_duration">atomic_bridge_configuration::counterparty_timelock_duration</a>();
     <b>let</b> details = <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">atomic_bridge_store::create_details</a>(
         ethereum_address,
         recipient,
@@ -2749,8 +2862,7 @@ The amount is burnt from the initiator
 ) {
     <b>let</b> ethereum_address = <a href="atomic_bridge.md#0x1_ethereum_ethereum_address">ethereum::ethereum_address</a>(recipient);
     <b>let</b> initiator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(initiator);
-    <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_time_lock">atomic_bridge_store::create_time_lock</a>(
-        <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initiator_timelock_duration">atomic_bridge_configuration::initiator_timelock_duration</a>());
+    <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_initiator_timelock_duration">atomic_bridge_configuration::initiator_timelock_duration</a>();
 
     <b>let</b> details =
         <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">atomic_bridge_store::create_details</a>(

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -8,6 +8,7 @@
 -  [Struct `EthereumAddress`](#0x1_ethereum_EthereumAddress)
 -  [Constants](#@Constants_0)
 -  [Function `ethereum_address`](#0x1_ethereum_ethereum_address)
+-  [Function `ethereum_address_no_eip55`](#0x1_ethereum_ethereum_address_no_eip55)
 -  [Function `to_lowercase`](#0x1_ethereum_to_lowercase)
 -  [Function `to_eip55_checksumed_address`](#0x1_ethereum_to_eip55_checksumed_address)
 -  [Function `get_inner`](#0x1_ethereum_get_inner)
@@ -112,6 +113,35 @@ Validates an Ethereum address against EIP-55 checksum rules and returns a new <c
 
 <pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_ethereum_address">ethereum_address</a>(ethereum_address: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a> {
     <a href="atomic_bridge.md#0x1_ethereum_assert_eip55">assert_eip55</a>(&ethereum_address);
+    <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a> { inner: ethereum_address }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_ethereum_ethereum_address_no_eip55"></a>
+
+## Function `ethereum_address_no_eip55`
+
+Returns a new <code><a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a></code> without EIP-55 validation.
+
+@param ethereum_address A 40-byte vector of unsigned 8-bit integers (hexadecimal format).
+@return A validated <code><a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a></code> struct.
+@abort If the address does not conform to EIP-55 standards.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_ethereum_address_no_eip55">ethereum_address_no_eip55</a>(ethereum_address: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_ethereum_address_no_eip55">ethereum_address_no_eip55</a>(ethereum_address: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a> {
     <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a> { inner: ethereum_address }
 }
 </code></pre>
@@ -2575,7 +2605,7 @@ Locks assets for a bridge transfer by the initiator.
     amount: u64
 ) {
     <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_assert_is_caller_operator">atomic_bridge_configuration::assert_is_caller_operator</a>(caller);
-    <b>let</b> ethereum_address = <a href="atomic_bridge.md#0x1_ethereum_ethereum_address">ethereum::ethereum_address</a>(initiator);
+    <b>let</b> ethereum_address = <a href="atomic_bridge.md#0x1_ethereum_ethereum_address_no_eip55">ethereum::ethereum_address_no_eip55</a>(initiator);
     <b>let</b> time_lock = <a href="atomic_bridge.md#0x1_atomic_bridge_configuration_counterparty_timelock_duration">atomic_bridge_configuration::counterparty_timelock_duration</a>();
     <b>let</b> details = <a href="atomic_bridge.md#0x1_atomic_bridge_store_create_details">atomic_bridge_store::create_details</a>(
         ethereum_address,

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -40,6 +40,8 @@
 <b>use</b> <a href="aptos_coin.md#0x1_aptos_coin">0x1::aptos_coin</a>;
 <b>use</b> <a href="aptos_governance.md#0x1_aptos_governance">0x1::aptos_governance</a>;
 <b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge">0x1::atomic_bridge</a>;
+<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty">0x1::atomic_bridge_counterparty</a>;
+<b>use</b> <a href="atomic_bridge.md#0x1_atomic_bridge_initiator">0x1::atomic_bridge_initiator</a>;
 <b>use</b> <a href="block.md#0x1_block">0x1::block</a>;
 <b>use</b> <a href="chain_id.md#0x1_chain_id">0x1::chain_id</a>;
 <b>use</b> <a href="chain_status.md#0x1_chain_status">0x1::chain_status</a>;
@@ -367,6 +369,8 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     <a href="state_storage.md#0x1_state_storage_initialize">state_storage::initialize</a>(&aptos_framework_account);
     <a href="timestamp.md#0x1_timestamp_set_time_has_started">timestamp::set_time_has_started</a>(&aptos_framework_account);
     <a href="atomic_bridge.md#0x1_atomic_bridge_initialize">atomic_bridge::initialize</a>(&aptos_framework_account);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_initiator_initialize">atomic_bridge_initiator::initialize</a>(&aptos_framework_account);
+    <a href="atomic_bridge.md#0x1_atomic_bridge_counterparty_initialize">atomic_bridge_counterparty::initialize</a>(&aptos_framework_account);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -186,7 +186,7 @@ module aptos_framework::atomic_bridge_initiator {
     }
 
     /// Initializes the module and stores the `EventHandle`s in the resource.
-    fun init_module(aptos_framework: &signer) {
+    public fun initialize(aptos_framework: &signer) {
         move_to(aptos_framework, BridgeInitiatorEvents {
             bridge_transfer_initiated_events: account::new_event_handle<BridgeTransferInitiatedEvent>(aptos_framework),
             bridge_transfer_completed_events: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
@@ -278,7 +278,7 @@ module aptos_framework::atomic_bridge_initiator {
         // Create an account for our recipient
         atomic_bridge::initialize_for_test(aptos_framework);
         aptos_account::create_account(sender_address);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
 
         let recipient = valid_eip55();
         let hash_lock = valid_hash_lock();
@@ -344,7 +344,7 @@ module aptos_framework::atomic_bridge_initiator {
         let sender_address = signer::address_of(sender);
         // Create an account for our recipient
         atomic_bridge::initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         aptos_account::create_account(sender_address);
 
         let recipient = valid_eip55();
@@ -398,7 +398,7 @@ module aptos_framework::atomic_bridge_initiator {
         let sender_address = signer::address_of(sender);
         // Create an account for our recipient
         atomic_bridge::initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         aptos_account::create_account(sender_address);
 
         let recipient = valid_eip55();
@@ -442,7 +442,7 @@ module aptos_framework::atomic_bridge_initiator {
         let sender_address = signer::address_of(sender);
         // Create an account for our recipient
         atomic_bridge::initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         aptos_account::create_account(sender_address);
 
         let recipient = valid_eip55();
@@ -506,7 +506,7 @@ module aptos_framework::atomic_bridge_initiator {
         let sender_address = signer::address_of(sender);
         // Create an account for our recipient
         atomic_bridge::initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         aptos_account::create_account(sender_address);
 
         let recipient = valid_eip55();
@@ -559,7 +559,7 @@ module aptos_framework::atomic_bridge_initiator {
         let sender_address = signer::address_of(sender);
         // Create an account for our recipient
         atomic_bridge::initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         aptos_account::create_account(sender_address);
 
         let recipient = valid_eip55();
@@ -1435,7 +1435,7 @@ module aptos_framework::atomic_bridge_counterparty {
     }
 
     /// Initializes the module and stores the `EventHandle`s in the resource.
-    fun init_module(aptos_framework: &signer) {
+    public fun initialize(aptos_framework: &signer) {
         move_to(aptos_framework, BridgeCounterpartyEvents {
             bridge_transfer_locked_events: account::new_event_handle<BridgeTransferLockedEvent>(aptos_framework),
             bridge_transfer_completed_events: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
@@ -1542,7 +1542,7 @@ module aptos_framework::atomic_bridge_counterparty {
     #[test(aptos_framework = @aptos_framework)]
     fun test_lock_assets(aptos_framework: &signer) acquires BridgeCounterpartyEvents {
         initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         let initiator = valid_eip55();
         let bridge_transfer_id = valid_bridge_transfer_id();
         let hash_lock = valid_hash_lock();
@@ -1575,7 +1575,7 @@ module aptos_framework::atomic_bridge_counterparty {
     #[test(aptos_framework = @aptos_framework)]
     fun test_abort_transfer_of_assets(aptos_framework: &signer) acquires BridgeCounterpartyEvents {
         initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         let initiator = valid_eip55();
         let bridge_transfer_id = valid_bridge_transfer_id();
         let hash_lock = valid_hash_lock();
@@ -1601,7 +1601,7 @@ module aptos_framework::atomic_bridge_counterparty {
     #[test(aptos_framework = @aptos_framework)]
     fun test_complete_transfer_of_assets(aptos_framework: &signer) acquires BridgeCounterpartyEvents {
         initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         let initiator = valid_eip55();
         let bridge_transfer_id = valid_bridge_transfer_id();
         let hash_lock = valid_hash_lock();
@@ -1634,7 +1634,7 @@ module aptos_framework::atomic_bridge_counterparty {
     #[expected_failure(abort_code = 0x1, location = atomic_bridge_store)]
     fun test_failing_complete_transfer_of_assets(aptos_framework: &signer) acquires BridgeCounterpartyEvents {
         initialize_for_test(aptos_framework);
-        init_module(aptos_framework);
+        initialize(aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
         let initiator = valid_eip55();
         let bridge_transfer_id = valid_bridge_transfer_id();

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -180,17 +180,17 @@ module aptos_framework::atomic_bridge_initiator {
 
     /// This struct will store the event handles for bridge events.
     struct BridgeInitiatorEvents has key, store {
-        bridge_transfer_initiated: EventHandle<BridgeTransferInitiatedEvent>,
-        bridge_transfer_completed: EventHandle<BridgeTransferCompletedEvent>,
-        bridge_transfer_refunded: EventHandle<BridgeTransferRefundedEvent>,
+        bridge_transfer_initiated_events: EventHandle<BridgeTransferInitiatedEvent>,
+        bridge_transfer_completed_events: EventHandle<BridgeTransferCompletedEvent>,
+        bridge_transfer_refunded_events: EventHandle<BridgeTransferRefundedEvent>,
     }
 
     /// Initializes the module and stores the `EventHandle`s in the resource.
     fun init_module(aptos_framework: &signer) {
         move_to(aptos_framework, BridgeInitiatorEvents {
-            bridge_transfer_initiated: account::new_event_handle<BridgeTransferInitiatedEvent>(aptos_framework),
-            bridge_transfer_completed: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
-            bridge_transfer_refunded: account::new_event_handle<BridgeTransferRefundedEvent>(aptos_framework),
+            bridge_transfer_initiated_events: account::new_event_handle<BridgeTransferInitiatedEvent>(aptos_framework),
+            bridge_transfer_completed_events: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
+            bridge_transfer_refunded_events: account::new_event_handle<BridgeTransferRefundedEvent>(aptos_framework),
         });
     }
 
@@ -221,7 +221,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global_mut<BridgeInitiatorEvents>(@aptos_framework);
         event::emit_event(
-            &mut bridge_initiator_events.bridge_transfer_initiated,
+            &mut bridge_initiator_events.bridge_transfer_initiated_events,
             BridgeTransferInitiatedEvent {
                 bridge_transfer_id,
                 initiator: initiator_address,
@@ -244,7 +244,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global_mut<BridgeInitiatorEvents>(@aptos_framework);
         event::emit_event(
-            &mut bridge_initiator_events.bridge_transfer_completed,
+            &mut bridge_initiator_events.bridge_transfer_completed_events,
             BridgeTransferCompletedEvent {
                 bridge_transfer_id,
                 pre_image,
@@ -262,7 +262,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global_mut<BridgeInitiatorEvents>(@aptos_framework);
         event::emit_event(
-            &mut bridge_initiator_events.bridge_transfer_refunded,
+            &mut bridge_initiator_events.bridge_transfer_refunded_events,
             BridgeTransferRefundedEvent {
                 bridge_transfer_id,
             },
@@ -301,7 +301,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(@aptos_framework);
         let bridge_transfer_initiated_events = event::emitted_events_by_handle(
-            &bridge_initiator_events.bridge_transfer_initiated
+            &bridge_initiator_events.bridge_transfer_initiated_events
         );   
         let bridge_transfer_initiated_event = vector::borrow(&bridge_transfer_initiated_events, 0);
 
@@ -367,7 +367,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(@aptos_framework);
         let bridge_transfer_initiated_events = event::emitted_events_by_handle(
-            &bridge_initiator_events.bridge_transfer_initiated
+            &bridge_initiator_events.bridge_transfer_initiated_events
         );   
         let bridge_transfer_initiated_event = vector::borrow(&bridge_transfer_initiated_events, 0);
 
@@ -380,7 +380,7 @@ module aptos_framework::atomic_bridge_initiator {
         );
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(signer::address_of(aptos_framework));
-        let complete_events = event::emitted_events_by_handle(&bridge_initiator_events.bridge_transfer_completed);
+        let complete_events = event::emitted_events_by_handle(&bridge_initiator_events.bridge_transfer_completed_events);
         let expected_event = BridgeTransferCompletedEvent {
             bridge_transfer_id,
             pre_image: plain_secret(),
@@ -420,7 +420,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(@aptos_framework);
         let bridge_transfer_initiated_events = event::emitted_events_by_handle(
-            &bridge_initiator_events.bridge_transfer_initiated
+            &bridge_initiator_events.bridge_transfer_initiated_events
         );   
         let bridge_transfer_initiated_event = vector::borrow(&bridge_transfer_initiated_events, 0);
 
@@ -464,7 +464,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(@aptos_framework);
         let bridge_transfer_initiated_events = event::emitted_events_by_handle(
-            &bridge_initiator_events.bridge_transfer_initiated
+            &bridge_initiator_events.bridge_transfer_initiated_events
         );   
         let bridge_transfer_initiated_event = vector::borrow(&bridge_transfer_initiated_events, 0);
 
@@ -530,7 +530,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(@aptos_framework);
         let bridge_transfer_initiated_events = event::emitted_events_by_handle(
-            &bridge_initiator_events.bridge_transfer_initiated
+            &bridge_initiator_events.bridge_transfer_initiated_events
         );   
         let bridge_transfer_initiated_event = vector::borrow(&bridge_transfer_initiated_events, 0);
 
@@ -543,7 +543,7 @@ module aptos_framework::atomic_bridge_initiator {
         assert!(coin::balance<AptosCoin>(sender_address) == account_balance, 0);
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(signer::address_of(aptos_framework));
-        let refund_events = event::emitted_events_by_handle(&bridge_initiator_events.bridge_transfer_refunded);
+        let refund_events = event::emitted_events_by_handle(&bridge_initiator_events.bridge_transfer_refunded_events);
         let expected_event = BridgeTransferRefundedEvent { bridge_transfer_id };
         let was_event_emitted = std::vector::contains(&refund_events, &expected_event);
         
@@ -584,7 +584,7 @@ module aptos_framework::atomic_bridge_initiator {
 
         let bridge_initiator_events = borrow_global<BridgeInitiatorEvents>(@aptos_framework);
         let bridge_transfer_initiated_events = event::emitted_events_by_handle(
-            &bridge_initiator_events.bridge_transfer_initiated
+            &bridge_initiator_events.bridge_transfer_initiated_events
         );   
         let bridge_transfer_initiated_event = vector::borrow(&bridge_transfer_initiated_events, 0);
 
@@ -1429,17 +1429,17 @@ module aptos_framework::atomic_bridge_counterparty {
 
     /// This struct will store the event handles for bridge events.
     struct BridgeCounterpartyEvents has key, store {
-        bridge_transfer_locked: EventHandle<BridgeTransferLockedEvent>,
-        bridge_transfer_completed: EventHandle<BridgeTransferCompletedEvent>,
-        bridge_transfer_cancelled: EventHandle<BridgeTransferCancelledEvent>,
+        bridge_transfer_locked_events: EventHandle<BridgeTransferLockedEvent>,
+        bridge_transfer_completed_events: EventHandle<BridgeTransferCompletedEvent>,
+        bridge_transfer_cancelled_events: EventHandle<BridgeTransferCancelledEvent>,
     }
 
     /// Initializes the module and stores the `EventHandle`s in the resource.
     fun init_module(aptos_framework: &signer) {
         move_to(aptos_framework, BridgeCounterpartyEvents {
-            bridge_transfer_locked: account::new_event_handle<BridgeTransferLockedEvent>(aptos_framework),
-            bridge_transfer_completed: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
-            bridge_transfer_cancelled: account::new_event_handle<BridgeTransferCancelledEvent>(aptos_framework),
+            bridge_transfer_locked_events: account::new_event_handle<BridgeTransferLockedEvent>(aptos_framework),
+            bridge_transfer_completed_events: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
+            bridge_transfer_cancelled_events: account::new_event_handle<BridgeTransferCancelledEvent>(aptos_framework),
         });
     }
 
@@ -1478,7 +1478,7 @@ module aptos_framework::atomic_bridge_counterparty {
         let bridge_events = borrow_global_mut<BridgeCounterpartyEvents>(@aptos_framework);
 
         event::emit_event(
-            &mut bridge_events.bridge_transfer_locked,
+            &mut bridge_events.bridge_transfer_locked_events,
             BridgeTransferLockedEvent {
                 bridge_transfer_id,
                 initiator,
@@ -1509,7 +1509,7 @@ module aptos_framework::atomic_bridge_counterparty {
         
         let bridge_counterparty_events = borrow_global_mut<BridgeCounterpartyEvents>(@aptos_framework);
         event::emit_event(
-            &mut bridge_counterparty_events.bridge_transfer_completed,
+            &mut bridge_counterparty_events.bridge_transfer_completed_events,
             BridgeTransferCompletedEvent {
                 bridge_transfer_id,
                 pre_image,
@@ -1532,7 +1532,7 @@ module aptos_framework::atomic_bridge_counterparty {
 
         let bridge_counterparty_events = borrow_global_mut<BridgeCounterpartyEvents>(@aptos_framework);
         event::emit_event(
-            &mut bridge_counterparty_events.bridge_transfer_cancelled,
+            &mut bridge_counterparty_events.bridge_transfer_cancelled_events,
             BridgeTransferCancelledEvent {
                 bridge_transfer_id,
             },
@@ -1557,7 +1557,7 @@ module aptos_framework::atomic_bridge_counterparty {
                                     amount);
 
         let bridge_counterparty_events = borrow_global<BridgeCounterpartyEvents>(signer::address_of(aptos_framework));
-        let lock_events = event::emitted_events_by_handle(&bridge_counterparty_events.bridge_transfer_locked);
+        let lock_events = event::emitted_events_by_handle(&bridge_counterparty_events.bridge_transfer_locked_events);
 
         // Assert that the event was emitted
         let expected_event = BridgeTransferLockedEvent {
@@ -1593,7 +1593,7 @@ module aptos_framework::atomic_bridge_counterparty {
         abort_bridge_transfer(aptos_framework, bridge_transfer_id);
 
         let bridge_counterparty_events = borrow_global<BridgeCounterpartyEvents>(signer::address_of(aptos_framework));
-        let cancel_events = event::emitted_events_by_handle(&bridge_counterparty_events.bridge_transfer_cancelled);
+        let cancel_events = event::emitted_events_by_handle(&bridge_counterparty_events.bridge_transfer_cancelled_events);
         let expected_event = BridgeTransferCancelledEvent { bridge_transfer_id };
         assert!(std::vector::contains(&cancel_events, &expected_event), 0);
     }
@@ -1621,7 +1621,7 @@ module aptos_framework::atomic_bridge_counterparty {
         complete_bridge_transfer(bridge_transfer_id, plain_secret());
 
         let bridge_counterparty_events = borrow_global<BridgeCounterpartyEvents>(signer::address_of(aptos_framework));
-        let complete_events = event::emitted_events_by_handle(&bridge_counterparty_events.bridge_transfer_completed);
+        let complete_events = event::emitted_events_by_handle(&bridge_counterparty_events.bridge_transfer_completed_events);
         let expected_event = BridgeTransferCompletedEvent {
             bridge_transfer_id,
             pre_image: plain_secret(),

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -24,6 +24,15 @@ module aptos_framework::ethereum {
         EthereumAddress { inner: ethereum_address }
     }
 
+    /// Returns a new `EthereumAddress` without EIP-55 validation.
+    ///
+    /// @param ethereum_address A 40-byte vector of unsigned 8-bit integers (hexadecimal format).
+    /// @return A validated `EthereumAddress` struct.
+    /// @abort If the address does not conform to EIP-55 standards.
+    public fun ethereum_address_no_eip55(ethereum_address: vector<u8>): EthereumAddress {
+        EthereumAddress { inner: ethereum_address }
+    }
+
     /// Converts uppercase ASCII characters in a vector to their lowercase equivalents.
     ///
     /// @param input A reference to a vector of ASCII characters.
@@ -1363,7 +1372,7 @@ module aptos_framework::atomic_bridge_counterparty {
         amount: u64
     ) {
         atomic_bridge_configuration::assert_is_caller_operator(caller);
-        let ethereum_address = ethereum::ethereum_address(initiator);
+        let ethereum_address = ethereum::ethereum_address_no_eip55(initiator);
         let time_lock = atomic_bridge_configuration::counterparty_timelock_duration();
         let details = atomic_bridge_store::create_details(
             ethereum_address,

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -203,7 +203,7 @@ module aptos_framework::atomic_bridge_initiator {
         hash_lock: vector<u8>,
         amount: u64
     ) acquires BridgeInitiatorEvents {
-        let ethereum_address = ethereum::ethereum_address(recipient);
+        let ethereum_address = ethereum::ethereum_address_no_eip55(recipient);
         let initiator_address = signer::address_of(initiator);
         let time_lock = atomic_bridge_configuration::initiator_timelock_duration();
 

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -30,6 +30,7 @@ module aptos_framework::ethereum {
     /// @return A validated `EthereumAddress` struct.
     /// @abort If the address does not conform to EIP-55 standards.
     public fun ethereum_address_no_eip55(ethereum_address: vector<u8>): EthereumAddress {
+        assert_40_char_hex(&ethereum_address);
         EthereumAddress { inner: ethereum_address }
     }
 
@@ -101,6 +102,39 @@ module aptos_framework::ethereum {
         for (index in 0..len) {
             assert!(vector::borrow(&eip55, index) == vector::borrow(ethereum_address, index), 0);
         };
+    }
+
+    /// Checks if an Ethereum address is a nonzero 40-character hexadecimal string.
+    ///
+    /// @param ethereum_address A reference to a vector of bytes representing the Ethereum address as characters.
+    /// @abort If the address is not 40 characters long, contains invalid characters, or is all zeros.
+    public fun assert_40_char_hex(ethereum_address: &vector<u8>) {
+        let len = vector::length(ethereum_address);
+
+        // Ensure the address is exactly 40 characters long
+        assert!(len == 40, 1);
+
+        // Ensure the address contains only valid hexadecimal characters
+        let is_zero = true;
+        for (index in 0..len) {
+            let char = *vector::borrow(ethereum_address, index);
+
+            // Check if the character is a valid hexadecimal character (0-9, a-f, A-F)
+            assert!(
+                (char >= 0x30 && char <= 0x39) || // '0' to '9'
+                (char >= 0x41 && char <= 0x46) || // 'A' to 'F'
+                (char >= 0x61 && char <= 0x66),  // 'a' to 'f'
+                2
+            );
+
+            // Check if the address is nonzero
+            if (char != 0x30) { // '0'
+                is_zero = false;
+            };
+        };
+
+        // Abort if the address is all zeros
+        assert!(!is_zero, 3);
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -601,7 +601,6 @@ module aptos_framework::atomic_bridge_store {
     use aptos_std::aptos_hash::keccak256;
     use aptos_std::smart_table;
     use aptos_std::smart_table::SmartTable;
-    use aptos_framework::atomic_bridge_configuration;
     use aptos_framework::ethereum::EthereumAddress;
     use aptos_framework::system_addresses;
     use aptos_framework::timestamp;
@@ -615,6 +614,8 @@ module aptos_framework::atomic_bridge_store {
     use std::hash::sha3_256;
     #[test_only]
     use aptos_framework::ethereum;
+    #[test_only]
+    use aptos_framework::atomic_bridge_configuration;
 
     /// Error codes
     const EINVALID_PRE_IMAGE : u64 = 0x1;
@@ -903,24 +904,24 @@ module aptos_framework::atomic_bridge_store {
         keccak256(combined_bytes)
     }
 
+    #[view]
     /// Gets initiator bridge transfer details given a bridge transfer ID
     ///
     /// @param bridge_transfer_id A 32-byte vector of unsigned 8-bit integers.
     /// @return A `BridgeTransferDetails` struct.
     /// @abort If there is no transfer in the atomic bridge store.
-    #[view]
     public fun get_bridge_transfer_details_initiator(
         bridge_transfer_id: vector<u8>
     ): BridgeTransferDetails<address, EthereumAddress> acquires SmartTableWrapper {
         get_bridge_transfer_details(bridge_transfer_id)
     }
-
+    
+    #[view]
     /// Gets counterparty bridge transfer details given a bridge transfer ID
     ///
     /// @param bridge_transfer_id A 32-byte vector of unsigned 8-bit integers.
     /// @return A `BridgeTransferDetails` struct.
     /// @abort If there is no transfer in the atomic bridge store.
-    #[view]
     public fun get_bridge_transfer_details_counterparty(
         bridge_transfer_id: vector<u8>
     ): BridgeTransferDetails<EthereumAddress, address> acquires SmartTableWrapper {
@@ -1390,8 +1391,6 @@ module aptos_framework::atomic_bridge_counterparty {
     use aptos_framework::ethereum;
     use aptos_framework::ethereum::EthereumAddress;
     use aptos_framework::event::{Self, EventHandle}; 
-    use aptos_framework::signer;
-
     #[test_only]
     use aptos_framework::aptos_account;
     #[test_only]
@@ -1400,6 +1399,8 @@ module aptos_framework::atomic_bridge_counterparty {
     use aptos_framework::atomic_bridge_store::{valid_bridge_transfer_id, valid_hash_lock, plain_secret};
     #[test_only]
     use aptos_framework::ethereum::valid_eip55;
+    #[test_only]
+    use aptos_framework::signer;
     #[test_only]
     use aptos_framework::timestamp;
 

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -11,6 +11,8 @@ module aptos_framework::genesis {
     use aptos_framework::aptos_coin::{Self, AptosCoin};
     use aptos_framework::aptos_governance;
     use aptos_framework::atomic_bridge;
+    use aptos_framework::atomic_bridge_initiator;
+    use aptos_framework::atomic_bridge_counterparty;
     use aptos_framework::block;
     use aptos_framework::chain_id;
     use aptos_framework::chain_status;
@@ -133,6 +135,8 @@ module aptos_framework::genesis {
         state_storage::initialize(&aptos_framework_account);
         timestamp::set_time_has_started(&aptos_framework_account);
         atomic_bridge::initialize(&aptos_framework_account);
+        atomic_bridge_initiator::initialize(&aptos_framework_account);
+        atomic_bridge_counterparty::initialize(&aptos_framework_account);
     }
 
     /// Genesis step 2: Initialize Aptos coin.


### PR DESCRIPTION
## Description
- Because `initiateBridgeTransfer` will already have been successfully called on the Eth initiator side, there is no need to check EIP-55 compliance in `atomic_bridge_counterparty::lock_bridge_transfer_assets`. 
- The bridge team has decided for event listening it would make sense to use event handles rather than module events for this iteration of the bridge.
- This PR adds an optional function `ethereum_address_no_eip55` containing a check `assert_40_char_hex` to check that the address is a nonzero 40-character hex string.

## How Has This Been Tested?
- Move unit tests: `aptos move test` passes for all tests in `aptos-move/framework/aptos-framework/sources`
- E2E Move tests: Navigate to `aptos-move/e2e-move-tests` and run `cargo test bridge`.
- Move prover (`aptos move prove`) results in success.

## Key Areas to Review

Note: I don't think this is an ideal long-term solution. If it's helpful for launching the bridge with consistent event monitoring in the short-term, for the sake of consistency with how event monitoring was done with the first iteration of Move modules.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x] I tested both happy and unhappy path of the functionality
- [x ] I have made corresponding changes to the documentation
