### PR TITLE
Native bridge: Modify param serialization to make bridge transfer IDs match on Move and Solidity sides in both L1 -> L2 and L2 -> L1 directions

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/bridge.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bridge.rs
@@ -311,15 +311,10 @@ fn test_native_bridge_initiate() {
     let bridge_transfer_initiated_event = bcs::from_bytes::<NativeBridgeTransferInitiatedEvent>(bridge_transfer_initiated_event.event_data()).unwrap();
 
     let bridge_transfer_id = bridge_transfer_initiated_event.bridge_transfer_id;
-    println!("Bridge transfer ID: {:?}", hex::encode(&bridge_transfer_id));
     let initiator = bridge_transfer_initiated_event.initiator;
-    println!("Initiator: {:?}", hex::encode(&initiator));
     let recipient = bridge_transfer_initiated_event.recipient;
-    println!("Recipient: {:?}", hex::encode(&recipient));
     let amount = bridge_transfer_initiated_event.amount;
-    println!("Amount: {:?}", &amount);
     let nonce = bridge_transfer_initiated_event.nonce;
-    println!("Nonce: {:?}", &nonce);
 
     let mut combined_bytes = Vec::new();
 
@@ -330,7 +325,6 @@ fn test_native_bridge_initiate() {
     // Convert recipient from hex to bytes
     let recipient_bytes = hex::decode(String::from_utf8(recipient).expect("Invalid UTF-8 recipient"))
     .expect("Failed to decode recipient hex");
-    println!("Recipient bytes: {:?}", recipient_bytes); 
     combined_bytes.extend(recipient_bytes);
 
     // Pad amount and nonce to 32 bytes
@@ -373,12 +367,10 @@ fn test_native_bridge_complete() {
     // Convert recipient from hex to bytes
     let initiator_bytes = hex::decode(String::from_utf8(initiator.clone()).expect("Invalid UTF-8 recipient"))
     .expect("Failed to decode recipient hex");
-    println!("Recipient bytes: {:?}", initiator_bytes); 
     combined_bytes.extend(initiator_bytes);
     combined_bytes.extend(bcs::to_bytes(&recipient.address()).expect("Failed to serialize recipient"));
     combined_bytes.extend(normalize_to_32_bytes(bcs::to_bytes(&amount).expect("Failed to serialize amount")));
     combined_bytes.extend(normalize_to_32_bytes(bcs::to_bytes(&nonce).expect("Failed to serialize nonce")));
-    println!("Combined bytes: {:?}", hex::encode(&combined_bytes));
     // Compute keccak256 hash using tiny-keccak
     let mut hasher = Keccak::v256();
     hasher.update(&combined_bytes);
@@ -387,8 +379,6 @@ fn test_native_bridge_complete() {
     hasher.finalize(&mut hash);
 
     // Compare the computed hash to `bridge_transfer_id`
-    println!("Expected bridge transfer ID: {:?}", hex::encode(hash));
-
     let original_balance = harness.read_aptos_balance(relayer.address());
     let gas_used = harness.evaluate_entry_function_gas(&relayer,
                                 str::parse("0x1::native_bridge::complete_bridge_transfer").unwrap(),

--- a/aptos-move/e2e-move-tests/src/tests/bridge.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bridge.rs
@@ -369,7 +369,12 @@ fn test_native_bridge_complete() {
     let mut combined_bytes = Vec::new();
 
     // Append serialized values to `combined_bytes`
-    combined_bytes.extend_from_slice(&hex::decode(&format!("0x{}", String::from_utf8_lossy(&initiator)).to_string()).unwrap());
+    
+    // Convert recipient from hex to bytes
+    let initiator_bytes = hex::decode(String::from_utf8(initiator.clone()).expect("Invalid UTF-8 recipient"))
+    .expect("Failed to decode recipient hex");
+    println!("Recipient bytes: {:?}", initiator_bytes); 
+    combined_bytes.extend(initiator_bytes);
     combined_bytes.extend(bcs::to_bytes(&recipient.address()).expect("Failed to serialize recipient"));
     combined_bytes.extend(normalize_to_32_bytes(bcs::to_bytes(&amount).expect("Failed to serialize amount")));
     combined_bytes.extend(normalize_to_32_bytes(bcs::to_bytes(&nonce).expect("Failed to serialize nonce")));

--- a/aptos-move/e2e-move-tests/src/tests/bridge.rs
+++ b/aptos-move/e2e-move-tests/src/tests/bridge.rs
@@ -228,89 +228,111 @@ struct NativeBridgeTransferCompletedEvent {
     nonce: u64,
 }
 
-fn normalize_to_32_bytes(value: u64) -> Vec<u8> {
-    let mut bytes = vec![0; 32]; // Create a 32-byte vector initialized to zero
-    let value_bytes = value.to_be_bytes(); // Convert `u64` to big-endian bytes (8 bytes)
-    bytes[32 - value_bytes.len()..].copy_from_slice(&value_bytes); // Right-align the `value_bytes`
-    bytes
+fn hex_to_bytes(input: Vec<u8>) -> Vec<u8> {
+    let mut result = Vec::new();
+    assert!(input.len() % 2 == 0, "Input length must be even for valid hex");
+
+    let mut i = 0;
+    while i < input.len() {
+        let high_nibble = ascii_hex_to_u8(input[i]);
+        let low_nibble = ascii_hex_to_u8(input[i + 1]);
+        let byte = (high_nibble << 4) | low_nibble;
+        result.push(byte);
+        i += 2;
+    }
+
+    result
 }
 
-fn compute_keccak256(data: &[u8]) -> Vec<u8> {
-    use tiny_keccak::{Hasher, Keccak};
+fn ascii_hex_to_u8(ch: u8) -> u8 {
+    match ch {
+        b'0'..=b'9' => ch - b'0',
+        b'A'..=b'F' => ch - b'A' + 10,
+        b'a'..=b'f' => ch - b'a' + 10,
+        _ => panic!("Invalid hex character: {}", ch),
+    }
+}
 
-    let mut hasher = Keccak::v256();
-    hasher.update(data);
-
-    let mut output = [0u8; 32];
-    hasher.finalize(&mut output);
-
-    output.to_vec()
+fn normalize_to_32_bytes(value: Vec<u8>) -> Vec<u8> {
+    let mut padded = vec![0u8; 32 - value.len()]; // Left-padding
+    padded.extend(value);
+    padded
 }
 
 #[test]
+// A bridge is initiated with said amount to recipient on the destination chain
+// A relayer confirms that the initiate bridge transfer is successful and validates the details
 fn test_native_bridge_initiate() {
     let mut harness = MoveHarness::new();
 
     native_bridge_feature(&mut harness);
     run_mint_burn_caps_native(&mut harness);
 
-    let initiator = harness.new_account_at(AccountAddress::from_hex_literal("0xCAFE").unwrap());
-    let recipient = hex::decode("32Be343B94f860124dC4fEe278FDCBD38C102D88").unwrap(); // Ethereum address as raw bytes
-    println!("Recipient: {:?}", recipient);
-    let amount = 1_000_000; // 0.1
+    let initiator = harness.new_account_at(AccountAddress::from_hex_literal("0x726563697069656e740000000000000000000000000000000000000000000000").unwrap());
+    let recipient = b"5B38Da6a701c568545dCfcB03FcB875f56beddC4".to_vec();
+    let amount = 100; // 0.1
 
     let original_balance = harness.read_aptos_balance(initiator.address());
-
-    let gas_used = harness.evaluate_entry_function_gas(
-        &initiator,
-        str::parse("0x1::native_bridge::initiate_bridge_transfer").unwrap(),
-        vec![],
-        vec![
-            MoveValue::vector_u8(recipient.clone()).simple_serialize().unwrap(),
-            MoveValue::U64(amount).simple_serialize().unwrap(),
-        ],
-    );
+    let gas_used = harness.evaluate_entry_function_gas(&initiator,
+                                str::parse("0x1::native_bridge::initiate_bridge_transfer").unwrap(),
+                                vec![],
+                                vec![
+                                    MoveValue::vector_u8(recipient.clone()).simple_serialize().unwrap(),
+                                    MoveValue::U64(amount).simple_serialize().unwrap(),
+                                ],);
 
     let gas_used = gas_used * harness.default_gas_unit_price;
     let new_balance = harness.read_aptos_balance(initiator.address());
     assert_eq!(original_balance - amount - gas_used, new_balance);
 
     let events = harness.get_events();
-    let bridge_transfer_initiated_event_tag =
-        TypeTag::from_str("0x1::native_bridge::BridgeTransferInitiatedEvent").unwrap();
-    let bridge_transfer_initiated_event = events
-        .iter()
-        .find(|element| element.type_tag() == &bridge_transfer_initiated_event_tag)
-        .unwrap();
-    let bridge_transfer_initiated_event =
-        bcs::from_bytes::<NativeBridgeTransferInitiatedEvent>(
-            bridge_transfer_initiated_event.event_data(),
-        )
-        .unwrap();
+    let bridge_transfer_initiated_event_tag = TypeTag::from_str("0x1::native_bridge::BridgeTransferInitiatedEvent").unwrap();
+    let bridge_transfer_initiated_event = events.iter().find(|element| element.type_tag() == &bridge_transfer_initiated_event_tag).unwrap();
+    let bridge_transfer_initiated_event = bcs::from_bytes::<NativeBridgeTransferInitiatedEvent>(bridge_transfer_initiated_event.event_data()).unwrap();
 
     let bridge_transfer_id = bridge_transfer_initiated_event.bridge_transfer_id;
+    println!("Bridge transfer ID: {:?}", hex::encode(&bridge_transfer_id));
     let initiator = bridge_transfer_initiated_event.initiator;
+    println!("Initiator: {:?}", hex::encode(&initiator));
     let recipient = bridge_transfer_initiated_event.recipient;
+    println!("Recipient: {:?}", hex::encode(&recipient));
     let amount = bridge_transfer_initiated_event.amount;
+    println!("Amount: {:?}", &amount);
     let nonce = bridge_transfer_initiated_event.nonce;
+    println!("Nonce: {:?}", &nonce);
 
     let mut combined_bytes = Vec::new();
 
-    // Convert fields to match Move serialization
+    // Append serialized values to `combined_bytes` in the same way as in the Move function
+    // Serialize initiator as BCS bytes
     combined_bytes.extend(bcs::to_bytes(&initiator).expect("Failed to serialize initiator"));
-    combined_bytes.extend(recipient); // Already in raw bytes
-    combined_bytes.extend(normalize_to_32_bytes(amount));
-    combined_bytes.extend(normalize_to_32_bytes(nonce));
 
-    // Compute keccak256 hash
-    let bridge_transfer_id_expected = compute_keccak256(&combined_bytes);
+    // Convert recipient from hex to bytes
+    let recipient_bytes = hex::decode(String::from_utf8(recipient).expect("Invalid UTF-8 recipient"))
+    .expect("Failed to decode recipient hex");
+    println!("Recipient bytes: {:?}", recipient_bytes); 
+    combined_bytes.extend(recipient_bytes);
+
+    // Pad amount and nonce to 32 bytes
+    let amount_bytes = normalize_to_32_bytes(bcs::to_bytes(&amount).expect("Failed to serialize amount"));
+    let nonce_bytes = normalize_to_32_bytes(bcs::to_bytes(&nonce).expect("Failed to serialize nonce"));
+    combined_bytes.extend(amount_bytes);
+    combined_bytes.extend(nonce_bytes);
+
+    // Compute keccak256 hash using tiny-keccak
+    let mut hasher = Keccak::v256();
+    hasher.update(&combined_bytes);
+
+    let mut hash = [0u8; 32]; // Keccak256 outputs 32 bytes
+    hasher.finalize(&mut hash);
 
     // Compare the computed hash to `bridge_transfer_id`
-    assert_eq!(bridge_transfer_id, bridge_transfer_id_expected);
+    assert!(bridge_transfer_id == hash.to_vec());
 }
 
-
 #[test]
+// A bridge is initiated with said amount to recipient on the destination chain
+// A relayer confirms that the initiate bridge transfer is successful and validates the details
 fn test_native_bridge_complete() {
     let mut harness = MoveHarness::new();
 
@@ -319,60 +341,55 @@ fn test_native_bridge_complete() {
 
     let relayer = harness.new_account_at(AccountAddress::from_hex_literal("0x1").unwrap());
 
-    let initiator = hex::decode("32Be343B94f860124dC4fEe278FDCBD38C102D88").unwrap(); // Ethereum address as raw bytes
-    let recipient = harness.new_account_at(AccountAddress::from_hex_literal("0xCAFE").unwrap());
-    let amount = 1_000_000; // 0.1
-    let nonce = 5;
+    let initiator = b"5B38Da6a701c568545dCfcB03FcB875f56beddC4".to_vec();
+    let recipient = harness.new_account_at(AccountAddress::from_hex_literal("0x726563697069656e740000000000000000000000000000000000000000000000").unwrap());
+    let amount = 100; // 0.1
+    let nonce = 1;
 
     let mut combined_bytes = Vec::new();
 
-    // Convert fields to match Move serialization
-    combined_bytes.extend(initiator.clone()); // Already in raw bytes
+    // Append serialized values to `combined_bytes`
+    combined_bytes.extend(initiator.clone());
     combined_bytes.extend(bcs::to_bytes(&recipient.address()).expect("Failed to serialize recipient"));
-    combined_bytes.extend(normalize_to_32_bytes(amount));
-    combined_bytes.extend(normalize_to_32_bytes(nonce));
+    combined_bytes.extend(normalize_to_32_bytes(bcs::to_bytes(&amount).expect("Failed to serialize amount")));
+    combined_bytes.extend(normalize_to_32_bytes(bcs::to_bytes(&nonce).expect("Failed to serialize nonce")));
 
-    // Compute keccak256 hash
-    let bridge_transfer_id_expected = compute_keccak256(&combined_bytes);
+    // Compute keccak256 hash using tiny-keccak
+    let mut hasher = Keccak::v256();
+    hasher.update(&combined_bytes);
 
-    println!("Expected bridge transfer ID: {:?}", bridge_transfer_id_expected);
+    let mut hash = [0u8; 32]; // Keccak256 outputs 32 bytes
+    hasher.finalize(&mut hash);
+
+    // Compare the computed hash to `bridge_transfer_id`
+    println!("Expected bridge transfer ID: {:?}", hex::decode(hash.to_vec()));
 
     let original_balance = harness.read_aptos_balance(relayer.address());
-    let gas_used = harness.evaluate_entry_function_gas(
-        &relayer,
-        str::parse("0x1::native_bridge::complete_bridge_transfer").unwrap(),
-        vec![],
-        vec![
-            MoveValue::vector_u8(bridge_transfer_id_expected.clone()).simple_serialize().unwrap(),
-            MoveValue::vector_u8(initiator.clone()).simple_serialize().unwrap(),
-            MoveValue::Address(*recipient.address()).simple_serialize().unwrap(),
-            MoveValue::U64(amount).simple_serialize().unwrap(),
-            MoveValue::U64(nonce).simple_serialize().unwrap(),
-        ],
-    );
+    let gas_used = harness.evaluate_entry_function_gas(&relayer,
+                                str::parse("0x1::native_bridge::complete_bridge_transfer").unwrap(),
+                                vec![],
+                                vec![
+                                    MoveValue::vector_u8(hash.to_vec()).simple_serialize().unwrap(),
+                                    MoveValue::vector_u8(initiator.clone()).simple_serialize().unwrap(),
+                                    MoveValue::Address(*recipient.address()).simple_serialize().unwrap(),
+                                    MoveValue::U64(amount).simple_serialize().unwrap(),
+                                    MoveValue::U64(nonce).simple_serialize().unwrap(),
+                                ],);
 
     let gas_used = gas_used * harness.default_gas_unit_price;
     let new_balance = harness.read_aptos_balance(relayer.address());
     assert_eq!(original_balance - gas_used, new_balance);
 
     let events = harness.get_events();
-    let bridge_transfer_completed_event_tag =
-        TypeTag::from_str("0x1::native_bridge::BridgeTransferCompletedEvent").unwrap();
-    let bridge_transfer_completed_event = events
-        .iter()
-        .find(|element| element.type_tag() == &bridge_transfer_completed_event_tag)
-        .unwrap();
-    let bridge_transfer_completed_event =
-        bcs::from_bytes::<NativeBridgeTransferCompletedEvent>(
-            bridge_transfer_completed_event.event_data(),
-        )
-        .unwrap();
-
+    let bridge_transfer_completed_event_tag = TypeTag::from_str("0x1::native_bridge::BridgeTransferCompletedEvent").unwrap();
+    let bridge_transfer_completed_event = events.iter().find(|element| element.type_tag() == &bridge_transfer_completed_event_tag).unwrap();
+    let bridge_transfer_completed_event = bcs::from_bytes::<NativeBridgeTransferCompletedEvent>(bridge_transfer_completed_event.event_data()).unwrap();
+ 
     let bridge_transfer_id = bridge_transfer_completed_event.bridge_transfer_id;
+ 
+    assert_eq!(bridge_transfer_id, hash.to_vec());
 
-    assert_eq!(bridge_transfer_id, bridge_transfer_id_expected);
 }
-
 
 #[test]
 // A bridge is initiated with said amount to recipient on the destination chain

--- a/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/atomic_bridge.md
@@ -9,6 +9,7 @@
 -  [Constants](#@Constants_0)
 -  [Function `ethereum_address`](#0x1_ethereum_ethereum_address)
 -  [Function `ethereum_address_no_eip55`](#0x1_ethereum_ethereum_address_no_eip55)
+-  [Function `get_inner_ethereum_address`](#0x1_ethereum_get_inner_ethereum_address)
 -  [Function `to_lowercase`](#0x1_ethereum_to_lowercase)
 -  [Function `to_eip55_checksumed_address`](#0x1_ethereum_to_eip55_checksumed_address)
 -  [Function `get_inner`](#0x1_ethereum_get_inner)
@@ -145,6 +146,34 @@ Returns a new <code><a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">Ethe
 <pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_ethereum_address_no_eip55">ethereum_address_no_eip55</a>(ethereum_address: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a> {
     <a href="atomic_bridge.md#0x1_ethereum_assert_40_char_hex">assert_40_char_hex</a>(&ethereum_address);
     <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a> { inner: ethereum_address }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_ethereum_get_inner_ethereum_address"></a>
+
+## Function `get_inner_ethereum_address`
+
+Gets the inner vector of an <code><a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a></code>.
+
+@param ethereum_address A 40-byte vector of unsigned 8-bit integers (hexadecimal format).
+@return The vector<u8> inner value of the EthereumAddress
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_get_inner_ethereum_address">get_inner_ethereum_address</a>(ethereum_address: <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">ethereum::EthereumAddress</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="atomic_bridge.md#0x1_ethereum_get_inner_ethereum_address">get_inner_ethereum_address</a>(ethereum_address: <a href="atomic_bridge.md#0x1_ethereum_EthereumAddress">EthereumAddress</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    ethereum_address.inner
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/native_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/native_bridge.md
@@ -407,7 +407,7 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_bridge_transfer_id">bridge_transfer_id</a>(initiator: <b>address</b>, recipient: EthereumAddress, amount: u64, nonce: u64) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&initiator));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&recipient));
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="atomic_bridge.md#0x1_ethereum_get_inner_ethereum_address">ethereum::get_inner_ethereum_address</a>(recipient));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&amount));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce));
     keccak256(combined_bytes)
@@ -1648,7 +1648,7 @@ Initializes the module and stores the <code>EventHandle</code>s in the resource.
 
 ## Function `initiate_bridge_transfer`
 
-Initiate a bridge transfer of MOVE from Movement to the base layer
+Initiate a bridge transfer of MOVE from Movement to Ethereum
 Anyone can initiate a bridge transfer from the source chain
 The amount is burnt from the initiator and the module-level nonce is incremented
 @param initiator The initiator's Ethereum address as a vector of bytes.
@@ -1759,7 +1759,7 @@ Completes a bridge transfer by the initiator.
 
     // Validate the bridge_transfer_id by reconstructing the <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a>
     <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&initiator));
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, initiator);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&recipient));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&amount));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce));

--- a/aptos-move/framework/aptos-framework/doc/native_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/native_bridge.md
@@ -1479,8 +1479,6 @@ Burns a specified amount of AptosCoin from an address.
 -  [Function `increment_and_get_nonce`](#0x1_native_bridge_increment_and_get_nonce)
 -  [Function `initialize`](#0x1_native_bridge_initialize)
 -  [Function `initiate_bridge_transfer`](#0x1_native_bridge_initiate_bridge_transfer)
--  [Function `pad_to_32_bytes`](#0x1_native_bridge_pad_to_32_bytes)
--  [Function `truncate_to_20_bytes`](#0x1_native_bridge_truncate_to_20_bytes)
 -  [Function `complete_bridge_transfer`](#0x1_native_bridge_complete_bridge_transfer)
 -  [Specification](#@Specification_1)
     -  [Function `increment_and_get_nonce`](#@Specification_1_increment_and_get_nonce)
@@ -1846,65 +1844,6 @@ The amount is burnt from the initiator and the module-level nonce is incremented
             nonce,
         }
     );
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_native_bridge_pad_to_32_bytes"></a>
-
-## Function `pad_to_32_bytes`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_pad_to_32_bytes">pad_to_32_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_pad_to_32_bytes">pad_to_32_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> result = input;
-    <b>while</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&result) &lt; 32) {
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> result, 0); // Add padding
-    };
-    result
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_native_bridge_truncate_to_20_bytes"></a>
-
-## Function `truncate_to_20_bytes`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_truncate_to_20_bytes">truncate_to_20_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_truncate_to_20_bytes">truncate_to_20_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>let</b> result = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <b>let</b> length = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&input);
-    <b>let</b> i = 0;
-    <b>while</b> (i &lt; 20 && i &lt; length) {
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> result, *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&input, i));
-        i = i + 1;
-    };
-    result
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/native_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/native_bridge.md
@@ -9,6 +9,9 @@
 -  [Struct `OutboundTransfer`](#0x1_native_bridge_store_OutboundTransfer)
 -  [Constants](#@Constants_0)
 -  [Function `initialize`](#0x1_native_bridge_store_initialize)
+-  [Function `hex_to_bytes`](#0x1_native_bridge_store_hex_to_bytes)
+-  [Function `ascii_hex_to_u8`](#0x1_native_bridge_store_ascii_hex_to_u8)
+-  [Function `normalize_to_32_bytes`](#0x1_native_bridge_store_normalize_to_32_bytes)
 -  [Function `is_inbound_nonce_set`](#0x1_native_bridge_store_is_inbound_nonce_set)
 -  [Function `create_details`](#0x1_native_bridge_store_create_details)
 -  [Function `add`](#0x1_native_bridge_store_add)
@@ -218,6 +221,131 @@ Initializes the initiators tables and nonce.
 
 </details>
 
+<a id="0x1_native_bridge_store_hex_to_bytes"></a>
+
+## Function `hex_to_bytes`
+
+Takes an Ethereum address in ASCII hex, and converts to u8 (the raw Ethereum address bytes)
+@param input: the vector<u8> to convert to raw bytes
+@return vector of raw Ethereum address bytes (the human-readable characters of the address)
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_hex_to_bytes">hex_to_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_hex_to_bytes">hex_to_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>let</b> result = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+    <b>let</b> i = 0;
+
+    // Ensure the input length is valid (2 characters per byte)
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&input) % 2 == 0, 1);
+
+    <b>while</b> (i &lt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&input)) {
+        <b>let</b> high_nibble = <a href="native_bridge.md#0x1_native_bridge_store_ascii_hex_to_u8">ascii_hex_to_u8</a>(*<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&input, i));
+        <b>let</b> low_nibble = <a href="native_bridge.md#0x1_native_bridge_store_ascii_hex_to_u8">ascii_hex_to_u8</a>(*<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&input, i + 1));
+        <b>let</b> byte = (high_nibble &lt;&lt; 4) | low_nibble;
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> result, byte);
+        i = i + 2;
+    };
+
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_native_bridge_store_ascii_hex_to_u8"></a>
+
+## Function `ascii_hex_to_u8`
+
+
+
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_ascii_hex_to_u8">ascii_hex_to_u8</a>(ch: u8): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_ascii_hex_to_u8">ascii_hex_to_u8</a>(ch: u8): u8 {
+    <b>if</b> (ch &gt;= 0x30 && ch &lt;= 0x39) { // '0'-'9'
+        ch - 0x30
+    } <b>else</b> <b>if</b> (ch &gt;= 0x41 && ch &lt;= 0x46) { // 'A'-'F'
+        ch - 0x41 + 10
+    } <b>else</b> <b>if</b> (ch &gt;= 0x61 && ch &lt;= 0x66) { // 'a'-'f'
+        ch - 0x61 + 10
+    } <b>else</b> {
+        <b>assert</b>!(<b>false</b>, 2); // Abort <b>with</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">error</a> <a href="code.md#0x1_code">code</a> 2
+        0 // This is unreachable, but <b>ensures</b> type consistency
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_native_bridge_store_normalize_to_32_bytes"></a>
+
+## Function `normalize_to_32_bytes`
+
+Takes a vector, removes trailing zeroes, and pads with zeroes on the left until the value is 32 bytes.
+@param value: the vector<u8> to normalize
+@return 32-byte vector left-padded with zeroes, similar to how Ethereum serializes with abi.encodePacked
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_normalize_to_32_bytes">normalize_to_32_bytes</a>(value: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_normalize_to_32_bytes">normalize_to_32_bytes</a>(value: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>let</b> meaningful = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+    <b>let</b> i = 0;
+
+    // Remove trailing zeroes
+    <b>while</b> (i &lt; <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&value)) {
+        <b>if</b> (*<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&value, i) != 0x00) {
+            <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> meaningful, *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&value, i));
+        };
+        i = i + 1;
+    };
+
+    <b>let</b> result = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+
+    // Pad <b>with</b> zeros on the left
+    <b>let</b> padding_length = 32 - <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&meaningful);
+    <b>let</b> j = 0;
+    <b>while</b> (j &lt; padding_length) {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> result, 0x00);
+        j = j + 1;
+    };
+
+    // Append the meaningful bytes
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> result, meaningful);
+
+    result
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_native_bridge_store_is_inbound_nonce_set"></a>
 
 ## Function `is_inbound_nonce_set`
@@ -389,7 +517,7 @@ Asserts that the bridge transfer ID is valid.
 
 ## Function `bridge_transfer_id`
 
-Generates a unique bridge transfer ID based on transfer details and nonce.
+Generates a unique outbound bridge transfer ID based on transfer details and nonce.
 
 @param details The bridge transfer details.
 @return The generated bridge transfer ID.
@@ -405,11 +533,17 @@ Generates a unique bridge transfer ID based on transfer details and nonce.
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_store_bridge_transfer_id">bridge_transfer_id</a>(initiator: <b>address</b>, recipient: EthereumAddress, amount: u64, nonce: u64) : <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    // Serialize each param
+    <b>let</b> initiator_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>&lt;<b>address</b>&gt;(&initiator);
+    <b>let</b> recipient_bytes = <a href="native_bridge.md#0x1_native_bridge_store_hex_to_bytes">hex_to_bytes</a>(<a href="atomic_bridge.md#0x1_ethereum_get_inner_ethereum_address">ethereum::get_inner_ethereum_address</a>(recipient));
+    <b>let</b> amount_bytes = <a href="native_bridge.md#0x1_native_bridge_store_normalize_to_32_bytes">normalize_to_32_bytes</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>&lt;u64&gt;(&amount));
+    <b>let</b> nonce_bytes = <a href="native_bridge.md#0x1_native_bridge_store_normalize_to_32_bytes">normalize_to_32_bytes</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>&lt;u64&gt;(&nonce));
+    //Contatenate then <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a> and <b>return</b> bridge transfer ID
     <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&initiator));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="atomic_bridge.md#0x1_ethereum_get_inner_ethereum_address">ethereum::get_inner_ethereum_address</a>(recipient));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&amount));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce));
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, initiator_bytes);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, recipient_bytes);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, amount_bytes);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, nonce_bytes);
     keccak256(combined_bytes)
 }
 </code></pre>
@@ -1345,6 +1479,8 @@ Burns a specified amount of AptosCoin from an address.
 -  [Function `increment_and_get_nonce`](#0x1_native_bridge_increment_and_get_nonce)
 -  [Function `initialize`](#0x1_native_bridge_initialize)
 -  [Function `initiate_bridge_transfer`](#0x1_native_bridge_initiate_bridge_transfer)
+-  [Function `pad_to_32_bytes`](#0x1_native_bridge_pad_to_32_bytes)
+-  [Function `truncate_to_20_bytes`](#0x1_native_bridge_truncate_to_20_bytes)
 -  [Function `complete_bridge_transfer`](#0x1_native_bridge_complete_bridge_transfer)
 -  [Specification](#@Specification_1)
     -  [Function `increment_and_get_nonce`](#@Specification_1_increment_and_get_nonce)
@@ -1717,11 +1853,70 @@ The amount is burnt from the initiator and the module-level nonce is incremented
 
 </details>
 
+<a id="0x1_native_bridge_pad_to_32_bytes"></a>
+
+## Function `pad_to_32_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_pad_to_32_bytes">pad_to_32_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_pad_to_32_bytes">pad_to_32_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>let</b> result = input;
+    <b>while</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&result) &lt; 32) {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> result, 0); // Add padding
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_native_bridge_truncate_to_20_bytes"></a>
+
+## Function `truncate_to_20_bytes`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_truncate_to_20_bytes">truncate_to_20_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_truncate_to_20_bytes">truncate_to_20_bytes</a>(input: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>let</b> result = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
+    <b>let</b> length = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&input);
+    <b>let</b> i = 0;
+    <b>while</b> (i &lt; 20 && i &lt; length) {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> result, *<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_borrow">vector::borrow</a>(&input, i));
+        i = i + 1;
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_native_bridge_complete_bridge_transfer"></a>
 
 ## Function `complete_bridge_transfer`
 
-Completes a bridge transfer by the initiator.
+Completes a bridge transfer on the destination chain.
 
 @param caller The signer representing the bridge relayer.
 @param initiator The initiator's Ethereum address as a vector of bytes.
@@ -1754,15 +1949,21 @@ Completes a bridge transfer by the initiator.
 
     // Check <b>if</b> the bridge transfer ID is already associated <b>with</b> an inbound nonce
     <b>let</b> inbound_nonce_exists = <a href="native_bridge.md#0x1_native_bridge_store_is_inbound_nonce_set">native_bridge_store::is_inbound_nonce_set</a>(bridge_transfer_id);
-    <b>assert</b>!(!inbound_nonce_exists, <a href="native_bridge.md#0x1_native_bridge_ETRANSFER_ALREADY_PROCESSED">ETRANSFER_ALREADY_PROCESSED</a>); // Abort <b>if</b> the transfer is already processed
+    <b>assert</b>!(!inbound_nonce_exists, <a href="native_bridge.md#0x1_native_bridge_ETRANSFER_ALREADY_PROCESSED">ETRANSFER_ALREADY_PROCESSED</a>);
     <b>assert</b>!(nonce &gt; 0, <a href="native_bridge.md#0x1_native_bridge_EINVALID_NONCE">EINVALID_NONCE</a>);
 
     // Validate the bridge_transfer_id by reconstructing the <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">hash</a>
+    <b>let</b> initiator_bytes = <a href="native_bridge.md#0x1_native_bridge_store_hex_to_bytes">native_bridge_store::hex_to_bytes</a>(initiator);
+    <b>let</b> recipient_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&recipient);
+    <b>let</b> amount_bytes = <a href="native_bridge.md#0x1_native_bridge_store_normalize_to_32_bytes">native_bridge_store::normalize_to_32_bytes</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>&lt;u64&gt;(&amount));
+    <b>let</b> nonce_bytes = <a href="native_bridge.md#0x1_native_bridge_store_normalize_to_32_bytes">native_bridge_store::normalize_to_32_bytes</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>&lt;u64&gt;(&nonce));
+
     <b>let</b> combined_bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, initiator);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&recipient));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&amount));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&nonce));
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, initiator_bytes);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, recipient_bytes);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, amount_bytes);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> combined_bytes, nonce_bytes);
+
     <b>assert</b>!(keccak256(combined_bytes) == bridge_transfer_id, <a href="native_bridge.md#0x1_native_bridge_EINVALID_BRIDGE_TRANSFER_ID">EINVALID_BRIDGE_TRANSFER_ID</a>);
 
     // Record the transfer <b>as</b> completed by associating the bridge_transfer_id <b>with</b> the inbound nonce

--- a/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/atomic_bridge.move
@@ -34,6 +34,14 @@ module aptos_framework::ethereum {
         EthereumAddress { inner: ethereum_address }
     }
 
+    /// Gets the inner vector of an `EthereumAddress`.
+    ///
+    /// @param ethereum_address A 40-byte vector of unsigned 8-bit integers (hexadecimal format).
+    /// @return The vector<u8> inner value of the EthereumAddress
+    public fun get_inner_ethereum_address(ethereum_address: EthereumAddress): vector<u8> {
+        ethereum_address.inner
+    }
+
     /// Converts uppercase ASCII characters in a vector to their lowercase equivalents.
     ///
     /// @param input A reference to a vector of ASCII characters.

--- a/aptos-move/framework/aptos-framework/sources/native_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/native_bridge.move
@@ -134,25 +134,6 @@ module aptos_framework::native_bridge {
         );  
     }
 
-    public fun pad_to_32_bytes(input: vector<u8>): vector<u8> {
-        let result = input;
-        while (vector::length(&result) < 32) {
-            vector::push_back(&mut result, 0); // Add padding
-        };
-        result
-    }
-
-    public fun truncate_to_20_bytes(input: vector<u8>): vector<u8> {
-        let result = vector::empty<u8>();
-        let length = vector::length(&input);
-        let i = 0;
-        while (i < 20 && i < length) {
-            vector::push_back(&mut result, *vector::borrow(&input, i));
-            i = i + 1;
-        };
-        result
-    }
-
     /// Completes a bridge transfer on the destination chain.
     ///  
     /// @param caller The signer representing the bridge relayer.  

--- a/aptos-move/framework/aptos-framework/sources/native_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/native_bridge.move
@@ -15,8 +15,6 @@ module aptos_framework::native_bridge {
     use std::bcs;
     use std::vector;
     use aptos_std::aptos_hash::keccak256;
-    #[test_only]
-    use aptos_std::debug;
 
     const ETRANSFER_ALREADY_PROCESSED: u64 = 1;
     const EINVALID_BRIDGE_TRANSFER_ID: u64 = 2;
@@ -257,17 +255,6 @@ module aptos_framework::native_bridge {
         vector::append(&mut combined_bytes, bcs::to_bytes(&amount));
         vector::append(&mut combined_bytes, bcs::to_bytes(&nonce));
         let bridge_transfer_id = keccak256(combined_bytes);
-
-        debug::print(&initiator);
-        debug::print(&recipient);
-        debug::print(&amount);
-        debug::print(&nonce);
-
-        debug::print(&bcs::to_bytes(&recipient));
-        debug::print(&bcs::to_bytes(&amount));
-        debug::print(&bcs::to_bytes(&nonce));
-
-        debug::print(&bridge_transfer_id);
 
         // Create an account for our recipient
         aptos_account::create_account(recipient);

--- a/aptos-move/framework/aptos-framework/sources/native_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/native_bridge.move
@@ -15,6 +15,8 @@ module aptos_framework::native_bridge {
     use std::bcs;
     use std::vector;
     use aptos_std::aptos_hash::keccak256;
+    #[test_only]
+    use aptos_std::debug;
 
     const ETRANSFER_ALREADY_PROCESSED: u64 = 1;
     const EINVALID_BRIDGE_TRANSFER_ID: u64 = 2;
@@ -159,7 +161,7 @@ module aptos_framework::native_bridge {
 
         // Validate the bridge_transfer_id by reconstructing the hash
         let combined_bytes = vector::empty<u8>();
-        vector::append(&mut combined_bytes, bcs::to_bytes(&initiator));
+        vector::append(&mut combined_bytes, initiator);
         vector::append(&mut combined_bytes, bcs::to_bytes(&recipient));
         vector::append(&mut combined_bytes, bcs::to_bytes(&amount));
         vector::append(&mut combined_bytes, bcs::to_bytes(&nonce));
@@ -250,11 +252,22 @@ module aptos_framework::native_bridge {
 
         // Create a bridge transfer ID algorithmically
         let combined_bytes = vector::empty<u8>();
-        vector::append(&mut combined_bytes, bcs::to_bytes(&initiator));
+        vector::append(&mut combined_bytes, initiator);
         vector::append(&mut combined_bytes, bcs::to_bytes(&recipient));
         vector::append(&mut combined_bytes, bcs::to_bytes(&amount));
         vector::append(&mut combined_bytes, bcs::to_bytes(&nonce));
         let bridge_transfer_id = keccak256(combined_bytes);
+
+        debug::print(&initiator);
+        debug::print(&recipient);
+        debug::print(&amount);
+        debug::print(&nonce);
+
+        debug::print(&bcs::to_bytes(&recipient));
+        debug::print(&bcs::to_bytes(&amount));
+        debug::print(&bcs::to_bytes(&nonce));
+
+        debug::print(&bridge_transfer_id);
 
         // Create an account for our recipient
         aptos_account::create_account(recipient);

--- a/aptos-move/framework/aptos-framework/sources/native_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/native_bridge.move
@@ -13,8 +13,6 @@ module aptos_framework::native_bridge {
     #[test_only]
     use aptos_framework::ethereum::valid_eip55;
     use std::bcs;
-    #[test_only]
-    use aptos_std::debug;
     use std::vector;
     use aptos_std::aptos_hash::keccak256;
 
@@ -224,7 +222,6 @@ module aptos_framework::native_bridge {
         let initiated_events = event::emitted_events_by_handle(
             &bridge_events.bridge_transfer_initiated_events
         );
-        debug::print(&initiated_events);
         assert!(vector::length(&initiated_events) == 1, EEVENT_NOT_FOUND);
     }
 
@@ -265,7 +262,6 @@ module aptos_framework::native_bridge {
         vector::append(&mut combined_bytes, native_bridge_store::normalize_to_32_bytes(bcs::to_bytes(&amount)));
         vector::append(&mut combined_bytes, native_bridge_store::normalize_to_32_bytes(bcs::to_bytes(&nonce)));
         let bridge_transfer_id = keccak256(combined_bytes);
-        debug::print(&bridge_transfer_id);
 
         // Create an account for our recipient
         aptos_account::create_account(recipient);
@@ -290,7 +286,6 @@ module aptos_framework::native_bridge {
             amount,
             nonce,
         };
-        debug::print(&expected_event.bridge_transfer_id);
         assert!(std::vector::contains(&complete_events, &expected_event), 0);
         assert!(bridge_transfer_id == expected_event.bridge_transfer_id, 0)
     }

--- a/aptos-move/framework/aptos-framework/sources/native_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/native_bridge.move
@@ -352,6 +352,7 @@ module aptos_framework::native_bridge_store {
     use aptos_std::aptos_hash::keccak256;
     use aptos_std::smart_table;
     use aptos_std::smart_table::SmartTable;
+    use aptos_framework::ethereum;
     use aptos_framework::ethereum::EthereumAddress;
     use aptos_framework::system_addresses;
     use std::signer;
@@ -474,7 +475,7 @@ module aptos_framework::native_bridge_store {
     public(friend) fun bridge_transfer_id(initiator: address, recipient: EthereumAddress, amount: u64, nonce: u64) : vector<u8> {
         let combined_bytes = vector::empty<u8>();
         vector::append(&mut combined_bytes, bcs::to_bytes(&initiator));
-        vector::append(&mut combined_bytes, bcs::to_bytes(&recipient));
+        vector::append(&mut combined_bytes, ethereum::get_inner_ethereum_address(recipient));
         vector::append(&mut combined_bytes, bcs::to_bytes(&amount));
         vector::append(&mut combined_bytes, bcs::to_bytes(&nonce));
         keccak256(combined_bytes)

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -731,7 +731,7 @@ pub enum EntryFunctionCall {
         nonce: u64,
     },
 
-    /// Initiate a bridge transfer of MOVE from Movement to the base layer  
+    /// Initiate a bridge transfer of MOVE from Movement to Ethereum
     /// Anyone can initiate a bridge transfer from the source chain  
     /// The amount is burnt from the initiator and the module-level nonce is incremented  
     /// @param initiator The initiator's Ethereum address as a vector of bytes.  
@@ -3734,7 +3734,7 @@ pub fn native_bridge_complete_bridge_transfer(
     ))
 }
 
-/// Initiate a bridge transfer of MOVE from Movement to the base layer  
+/// Initiate a bridge transfer of MOVE from Movement to Ethereum
 /// Anyone can initiate a bridge transfer from the source chain  
 /// The amount is burnt from the initiator and the module-level nonce is incremented  
 /// @param initiator The initiator's Ethereum address as a vector of bytes.  

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -714,7 +714,7 @@ pub enum EntryFunctionCall {
         approved: bool,
     },
 
-    /// Completes a bridge transfer by the initiator.
+    /// Completes a bridge transfer on the destination chain.
 
     /// @param caller The signer representing the bridge relayer.  
     /// @param initiator The initiator's Ethereum address as a vector of bytes.  
@@ -3698,7 +3698,7 @@ pub fn multisig_account_vote_transanction(
     ))
 }
 
-/// Completes a bridge transfer by the initiator.
+/// Completes a bridge transfer on the destination chain.
 ///
 /// @param caller The signer representing the bridge relayer.  
 /// @param initiator The initiator's Ethereum address as a vector of bytes.  


### PR DESCRIPTION
## Description
See [Issue 905](https://github.com/movementlabsxyz/movement/issues/905). Param serialization on the Move side needs to be done the same way as on the Solidity side so the bridge transfer IDs will be equal. 

## Type of Change
- [ x] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
- Move unit tests: In `aptos-move/framework/aptos-framework` run `movement move test`
- E2E Move tests: In `aptos-move/e2e-move-tests` run `cargo test bridge -- --nocapture`

## Key Areas to Review

- I currently have left the debugging in to help reviewers see that the expected bridge transfer IDs are being calculated. Once reviewers are satisfied that this approach is correct, I'll remove the debugging. It was a bit of a mental workout getting this all working so I wanted to leave in a trail of breadcrumbs for the benefit of reviewers seeing that this is correct through the concrete debugging values printed.
- [This comment on 905](https://github.com/movementlabsxyz/movement/issues/905#issuecomment-2511924764) could be a good practical intro to any reviewers who would like to get their hands dirty on the Solidity side and verify that this is the correct serialization, including expected bridge transfer IDs for L1 -> L2 and L2 -> L1 given the specific params used in testing.

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x] I tested both happy and unhappy path of the functionality
- [ x] I have made corresponding changes to the documentation

