### PR TITLE
Move Rate Limiter

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/native_bridge.move
+++ b/aptos-move/framework/aptos-framework/sources/native_bridge.move
@@ -7,6 +7,7 @@ module aptos_framework::native_bridge {
     use aptos_framework::event::{Self, EventHandle}; 
     use aptos_framework::signer;
     use aptos_framework::system_addresses;
+    use aptos_framework::timestamp;
     #[test_only]
     use aptos_framework::aptos_account;
     #[test_only]
@@ -32,23 +33,37 @@ module aptos_framework::native_bridge {
     const EID_NOT_FOUND: u64 = 10;
     const EINVALID_BRIDGE_RELAYER: u64 = 11;
     const ESAME_FEE: u64 = 0x2;
+    const ESAME_VALUE: u64 = 0x3;
+    const ERATE_LIMIT_EXCEEDED: u64 = 0x4;
 
     friend aptos_framework::genesis;
 
-    struct AptosCoinBurnCapability has key {
-        burn_cap: BurnCapability<AptosCoin>,
+    #[event]
+    /// Event emitted when the bridge relayer is updated.
+    struct BridgeConfigRelayerUpdated has store, drop {
+        old_relayer: address,
+        new_relayer: address,
     }
 
-    struct AptosCoinMintCapability has key {
-        mint_cap: MintCapability<AptosCoin>,
+    #[event]
+    /// An event triggered upon change of bridgefee
+    struct BridgeFeeChangedEvent has store, drop {
+        old_bridge_fee: u64,
+        new_bridge_fee: u64,
     }
 
-    struct AptosFABurnCapabilities has key {
-        burn_ref: BurnRef,
+    #[event]
+    /// An event triggered upon change of risk denominator
+    struct BridgeRiskDenominatorChangedEvent has store, drop {
+        old_risk_denominator: u64,
+        new_risk_denominator: u64,
     }
 
-    struct AptosFAMintCapabilities has key {
-        burn_ref: MintRef,
+    #[event]
+    /// An event triggered upon change of insurance fund
+    struct BridgeInsuranceFundChangedEvent has store, drop {
+        old_insurance_fund: address,
+        new_insurance_fund: address,
     }
 
     #[event]
@@ -77,6 +92,22 @@ module aptos_framework::native_bridge {
         bridge_transfer_completed_events: EventHandle<BridgeTransferCompletedEvent>,
     }
 
+    struct AptosCoinBurnCapability has key {
+        burn_cap: BurnCapability<AptosCoin>,
+    }
+
+    struct AptosCoinMintCapability has key {
+        mint_cap: MintCapability<AptosCoin>,
+    }
+
+    struct AptosFABurnCapabilities has key {
+        burn_ref: BurnRef,
+    }
+
+    struct AptosFAMintCapabilities has key {
+        burn_ref: MintRef,
+    }
+
     /// A nonce to ensure the uniqueness of bridge transfers
     struct Nonce has key {
         value: u64
@@ -97,21 +128,60 @@ module aptos_framework::native_bridge {
 
     struct BridgeConfig has key {
         bridge_relayer: address,
+        insurance_fund: address,
+        risk_denominator: u64,
         bridge_fee: u64,
     }
 
-    #[event]
-    /// Event emitted when the bridge relayer is updated.
-    struct BridgeConfigRelayerUpdated has store, drop {
-        old_relayer: address,
-        new_relayer: address,
-    }
+    /// Initializes the module and stores the `EventHandle`s in the resource.
+    public fun initialize(aptos_framework: &signer) {
+        system_addresses::assert_aptos_framework(aptos_framework);
 
-    #[event]
-    /// An event triggered upon change of bridgefee
-    struct BridgeFeeChangedEvent has store, drop {
-        old_bridge_fee: u64,
-        new_bridge_fee: u64,
+        let bridge_config = BridgeConfig {
+            bridge_relayer: signer::address_of(aptos_framework),
+            insurance_fund: signer::address_of(aptos_framework),
+            risk_denominator: 4,
+            bridge_fee: 40_000_000_000,
+        };
+        move_to(aptos_framework, bridge_config);
+
+        // Ensure the nonce is not already initialized
+        assert!(
+            !exists<Nonce>(signer::address_of(aptos_framework)),
+            2
+        );
+
+        // Create the Nonce resource with an initial value of 0
+        move_to<Nonce>(aptos_framework, Nonce { 
+            value: 0
+        });
+
+        // Create the InboundRateLimitBudget resource
+        
+
+        move_to(aptos_framework, BridgeEvents {
+            bridge_transfer_initiated_events: account::new_event_handle<BridgeTransferInitiatedEvent>(aptos_framework),
+            bridge_transfer_completed_events: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
+        });
+        system_addresses::assert_aptos_framework(aptos_framework);
+
+        let inbound_rate_limit_budget = SmartTableWrapper<u64, u64> {
+            inner: smart_table::new(),
+        };
+
+        move_to(aptos_framework, inbound_rate_limit_budget);
+
+        let nonces_to_details = SmartTableWrapper<u64, OutboundTransfer> {
+            inner: smart_table::new(),
+        };
+
+        move_to(aptos_framework, nonces_to_details);
+
+        let ids_to_inbound_nonces = SmartTableWrapper<vector<u8>, u64> {
+            inner: smart_table::new(),
+        };
+
+        move_to(aptos_framework, ids_to_inbound_nonces);
     }
 
     /// Converts a u64 to a 32-byte vector.
@@ -215,6 +285,38 @@ module aptos_framework::native_bridge {
         vector::append(&mut combined_bytes, nonce_bytes);
         keccak256(combined_bytes)
     }
+
+    #[view]
+    /// Retrieves the address of the current bridge relayer.
+    ///
+    /// @return The address of the current bridge relayer.
+    public fun bridge_relayer(): address acquires BridgeConfig {
+        borrow_global_mut<BridgeConfig>(@aptos_framework).bridge_relayer
+    }
+
+    #[view]
+    /// Retrieves the address of the current insurance fund.
+    /// 
+    /// @return The address of the current insurance fund.
+    public fun insurance_fund(): address acquires BridgeConfig {
+        borrow_global_mut<BridgeConfig>(@aptos_framework).insurance_fund
+    }
+
+    #[view]
+    /// Retrieves the current risk denominator.
+    /// 
+    /// @return The current risk denominator.
+    public fun risk_denominator(): u64 acquires BridgeConfig {
+        borrow_global_mut<BridgeConfig>(@aptos_framework).risk_denominator
+    }
+
+    #[view]
+    /// Retrieves the current bridge fee.
+    /// 
+    /// @return The current bridge fee.
+    public fun bridge_fee(): u64 acquires BridgeConfig {
+        borrow_global_mut<BridgeConfig>(@aptos_framework).bridge_fee
+    }
     
     #[view]
     /// Gets the bridge transfer details (`OutboundTransfer`) from the given nonce.
@@ -251,47 +353,7 @@ module aptos_framework::native_bridge {
         let nonce_ref = borrow_global_mut<Nonce>(@aptos_framework);  
         nonce_ref.value = nonce_ref.value + 1;  
         nonce_ref.value  
-    }  
-
-    /// Initializes the module and stores the `EventHandle`s in the resource.
-    public fun initialize(aptos_framework: &signer) {
-        system_addresses::assert_aptos_framework(aptos_framework);
-
-        let bridge_config = BridgeConfig {
-            bridge_relayer: signer::address_of(aptos_framework),
-            bridge_fee: 40_000_000_000,
-        };
-        move_to(aptos_framework, bridge_config);
-
-        // Ensure the nonce is not already initialized
-        assert!(
-            !exists<Nonce>(signer::address_of(aptos_framework)),
-            2
-        );
-
-        // Create the Nonce resource with an initial value of 0
-        move_to<Nonce>(aptos_framework, Nonce { 
-            value: 0
-        });
-
-        move_to(aptos_framework, BridgeEvents {
-            bridge_transfer_initiated_events: account::new_event_handle<BridgeTransferInitiatedEvent>(aptos_framework),
-            bridge_transfer_completed_events: account::new_event_handle<BridgeTransferCompletedEvent>(aptos_framework),
-        });
-                system_addresses::assert_aptos_framework(aptos_framework);
-
-        let nonces_to_details = SmartTableWrapper<u64, OutboundTransfer> {
-            inner: smart_table::new(),
-        };
-
-        move_to(aptos_framework, nonces_to_details);
-
-        let ids_to_inbound_nonces = SmartTableWrapper<vector<u8>, u64> {
-            inner: smart_table::new(),
-        };
-
-        move_to(aptos_framework, ids_to_inbound_nonces);
-    }
+    } 
 
     #[test_only]
     /// Initializes the native bridge for testing purposes
@@ -439,6 +501,7 @@ module aptos_framework::native_bridge {
     ) acquires BridgeEvents, AptosCoinMintCapability, SmartTableWrapper, BridgeConfig {
         // Ensure the caller is the bridge relayer
         assert_is_caller_relayer(caller);
+        assert_rate_limit_budget_not_exceeded(amount);
 
         // Check if the bridge transfer ID is already associated with an inbound nonce
         let inbound_nonce_exists = is_inbound_nonce_set(bridge_transfer_id);
@@ -519,7 +582,7 @@ module aptos_framework::native_bridge {
     /// @param relayer The signer representing the Relayer.
     /// @param new_bridge_fee The new bridge fee to be set.
     /// @abort If the new bridge fee is the same as the old bridge fee.
-    public fun update_bridge_fee(relayer: &signer, new_bridge_fee: u64
+    public entry fun update_bridge_fee(relayer: &signer, new_bridge_fee: u64
     ) acquires BridgeConfig {
         assert_is_caller_relayer(relayer);
         let bridge_config = borrow_global_mut<BridgeConfig>(@aptos_framework);
@@ -535,20 +598,46 @@ module aptos_framework::native_bridge {
         );
     }
 
-    #[view]
-    /// Retrieves the address of the current bridge relayer.
-    ///
-    /// @return The address of the current bridge relayer.
-    public fun bridge_relayer(): address acquires BridgeConfig {
-        borrow_global_mut<BridgeConfig>(@aptos_framework).bridge_relayer
+    /// Updates the insurance fund, requiring governance validation.
+    /// 
+    /// @param aptos_framework The signer representing the Aptos framework.
+    /// @param new_insurance_fund The new insurance fund to be set.
+    /// @abort If the new insurance fund is the same as the old insurance fund.
+    public entry fun update_insurance_fund(aptos_framework: &signer, new_insurance_fund: address
+    ) acquires BridgeConfig {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        let bridge_config = borrow_global_mut<BridgeConfig>(@aptos_framework);
+        let old_insurance_fund = bridge_config.insurance_fund;
+        assert!(old_insurance_fund != new_insurance_fund, ESAME_VALUE);
+        bridge_config.insurance_fund = new_insurance_fund;
+
+        event::emit(
+            BridgeInsuranceFundChangedEvent {
+                old_insurance_fund,
+                new_insurance_fund,
+            },
+        );
     }
 
-    #[view]
-    /// Retrieves the current bridge fee.
+    /// Updates the risk denominator, requiring governance validation.
     /// 
-    /// @return The current bridge fee.
-    public fun bridge_fee(): u64 acquires BridgeConfig {
-        borrow_global_mut<BridgeConfig>(@aptos_framework).bridge_fee
+    /// @param aptos_framework The signer representing the Aptos framework.
+    /// @param new_risk_denominator The new risk denominator to be set.
+    /// @abort If the new risk denominator is the same as the old risk denominator.
+    public entry fun update_risk_denominator(aptos_framework: &signer, new_risk_denominator: u64
+    ) acquires BridgeConfig {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        let bridge_config = borrow_global_mut<BridgeConfig>(@aptos_framework);
+        let old_risk_denominator = bridge_config.risk_denominator;
+        assert!(old_risk_denominator != new_risk_denominator, ESAME_VALUE);
+        bridge_config.risk_denominator = new_risk_denominator;
+
+        event::emit(
+            BridgeRiskDenominatorChangedEvent {
+                old_risk_denominator,
+                new_risk_denominator,
+            },
+        );
     }
 
     /// Asserts that the caller is the current bridge relayer.
@@ -558,6 +647,21 @@ module aptos_framework::native_bridge {
     public(friend) fun assert_is_caller_relayer(caller: &signer
     ) acquires BridgeConfig {
         assert!(borrow_global<BridgeConfig>(@aptos_framework).bridge_relayer == signer::address_of(caller), EINVALID_BRIDGE_RELAYER);
+    }
+
+    /// Asserts that the rate limit budget is not exceeded.
+    /// 
+    /// @param amount The amount to be transferred.
+    fun assert_rate_limit_budget_not_exceeded(amount: u64) acquires SmartTableWrapper, BridgeConfig {
+        let insurance_fund = borrow_global<BridgeConfig>(@aptos_framework).insurance_fund;
+        let risk_denominator = borrow_global<BridgeConfig>(@aptos_framework).risk_denominator;
+        let table = borrow_global_mut<SmartTableWrapper<u64, u64>>(@aptos_framework);
+        
+        let day = timestamp::now_seconds() / 86400;
+        let current_budget = smart_table::borrow_mut_with_default(&mut table.inner, day, 0);
+        smart_table::upsert(&mut table.inner, day, *current_budget + amount);
+        let rate_limit = coin::balance<AptosCoin>(insurance_fund) / risk_denominator;
+        assert!(*smart_table::borrow(&table.inner, day) < rate_limit, ERATE_LIMIT_EXCEEDED);
     }
 
     #[test(aptos_framework = @aptos_framework)]
@@ -583,6 +687,44 @@ module aptos_framework::native_bridge {
             ), 0);
 
         assert!(bridge_relayer() == new_relayer, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    /// Tests updating the risk denominator and emitting the corresponding event.
+    fun test_update_risk_denominator(aptos_framework: &signer
+    ) acquires BridgeConfig {
+        initialize_for_test(aptos_framework);
+        let old_risk_denominator = risk_denominator();
+        let new_risk_denominator = 5;
+        update_risk_denominator(aptos_framework, new_risk_denominator);
+
+        assert!(
+            event::was_event_emitted<BridgeRiskDenominatorChangedEvent>(
+                &BridgeRiskDenominatorChangedEvent {
+                    old_risk_denominator: old_risk_denominator,
+                    new_risk_denominator: new_risk_denominator,
+                }
+            ), 0);
+
+        assert!(risk_denominator() == new_risk_denominator, 0);
+    }
+
+    #[test(aptos_framework = @aptos_framework, new_insurance_fund = @0xdead)]
+    /// Tests updating the insurance fund and emitting the corresponding event.
+    fun test_update_insurance_fund(aptos_framework: &signer, new_insurance_fund: address
+    ) acquires BridgeConfig {
+        initialize_for_test(aptos_framework);
+        update_insurance_fund(aptos_framework, new_insurance_fund);
+
+        assert!(
+            event::was_event_emitted<BridgeInsuranceFundChangedEvent>(
+                &BridgeInsuranceFundChangedEvent {
+                    old_insurance_fund: @aptos_framework,
+                    new_insurance_fund: new_insurance_fund,
+                }
+            ), 0);
+
+        assert!(insurance_fund() == new_insurance_fund, 0);
     }
 
     #[test(aptos_framework = @aptos_framework)]
@@ -706,6 +848,7 @@ module aptos_framework::native_bridge {
         initialize_for_test(aptos_framework);
         let initiator = b"5B38Da6a701c568545dCfcB03FcB875f56beddC4";
         let recipient = @0x726563697069656e740000000000000000000000000000000000000000000000;
+        let insurance_fund = @0xbeaf;
         let amount = 100;
         let nonce = 1;
 
@@ -717,9 +860,15 @@ module aptos_framework::native_bridge {
         vector::append(&mut combined_bytes, normalize_u64_to_32_bytes(&nonce));
         let bridge_transfer_id = keccak256(combined_bytes);
 
+        aptos_account::create_account(insurance_fund);
+        update_insurance_fund(aptos_framework, insurance_fund);
+
+        // grant the insurance fund 4 * amount of coins
+        mint(insurance_fund, amount * 4 + 4);
+
         // Create an account for our recipient
         aptos_account::create_account(recipient);
-
+        timestamp::set_time_has_started_for_testing(aptos_framework);
         complete_bridge_transfer(
             aptos_framework,
             bridge_transfer_id,
@@ -742,6 +891,95 @@ module aptos_framework::native_bridge {
         };
         assert!(std::vector::contains(&complete_events, &expected_event), 0);
         assert!(bridge_transfer_id == expected_event.bridge_transfer_id, 0)
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    #[expected_failure(abort_code = 4, location = Self)] 
+    fun test_complete_bridge_transfer_rate_limit(aptos_framework: &signer) acquires BridgeEvents, AptosCoinMintCapability, SmartTableWrapper, BridgeConfig {
+        initialize_for_test(aptos_framework);
+        let initiator = b"5B38Da6a701c568545dCfcB03FcB875f56beddC4";
+        let recipient = @0x726563697069656e740000000000000000000000000000000000000000000000;
+        let insurance_fund = @0xbeaf;
+        let day = 86400;
+        let amount = 100;
+        let nonce = 1;
+
+        // Create a bridge transfer ID algorithmically
+        let combined_bytes = vector::empty<u8>();
+        vector::append(&mut combined_bytes, initiator);
+        vector::append(&mut combined_bytes, bcs::to_bytes(&recipient));
+        vector::append(&mut combined_bytes, normalize_u64_to_32_bytes(&amount));
+        vector::append(&mut combined_bytes, normalize_u64_to_32_bytes(&nonce));
+        let bridge_transfer_id = keccak256(combined_bytes);
+
+        aptos_account::create_account(insurance_fund);
+        update_insurance_fund(aptos_framework, insurance_fund);
+
+        // grant the insurance fund 4 * amount of coins
+        mint(insurance_fund, amount * 4 + 4);
+
+        // Create an account for our recipient
+        aptos_account::create_account(recipient);
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        complete_bridge_transfer(
+            aptos_framework,
+            bridge_transfer_id,
+            initiator,
+            recipient,
+            amount,
+            nonce
+        );
+
+        let bridge_events = borrow_global<BridgeEvents>(signer::address_of(aptos_framework));
+        let complete_events = event::emitted_events_by_handle(&bridge_events.bridge_transfer_completed_events);
+
+        // Assert that the event was emitted
+        let expected_event = BridgeTransferCompletedEvent {
+            bridge_transfer_id,
+            initiator,
+            recipient,
+            amount,
+            nonce,
+        };
+        assert!(std::vector::contains(&complete_events, &expected_event), 0);
+        assert!(bridge_transfer_id == expected_event.bridge_transfer_id, 0);
+
+        // reset the rate limit
+        timestamp::fast_forward_seconds(day);
+
+        nonce = nonce + 1;
+        let combined_bytes2 = vector::empty<u8>();
+        vector::append(&mut combined_bytes2, initiator);
+        vector::append(&mut combined_bytes2, bcs::to_bytes(&recipient));
+        vector::append(&mut combined_bytes2, normalize_u64_to_32_bytes(&amount));
+        vector::append(&mut combined_bytes2, normalize_u64_to_32_bytes(&nonce));
+        let bridge_transfer_id2 = keccak256(combined_bytes2);
+        complete_bridge_transfer(
+            aptos_framework,
+            bridge_transfer_id2,
+            initiator,
+            recipient,
+            amount,
+            nonce
+        );
+        
+        nonce = nonce + 1;
+
+        let combined_bytes3 = vector::empty<u8>();
+        vector::append(&mut combined_bytes3, initiator);
+        vector::append(&mut combined_bytes3, bcs::to_bytes(&recipient));
+        vector::append(&mut combined_bytes3, normalize_u64_to_32_bytes(&amount));
+        vector::append(&mut combined_bytes3, normalize_u64_to_32_bytes(&nonce));
+        let bridge_transfer_id3 = keccak256(combined_bytes2);
+        // expect to fail as it reaches the rate limit
+        complete_bridge_transfer(
+            aptos_framework,
+            bridge_transfer_id3,
+            initiator,
+            recipient,
+            amount,
+            nonce
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, sender = @0xdaff)]


### PR DESCRIPTION
## Description
Rate Limits the Relayer capability of calling complete_bridge_transfer based on an insurance fund address, similar to the bridge counterparty on Solidity. https://github.com/movementlabsxyz/movement/issues/836

## How Has This Been Tested?
Mirrors testing of rate limit on Solidity but without fuzzing

## Key Areas to Review
Test coverage

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
