### PR TITLE
GGP feat: assert framework signer for deposit from 

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -127,7 +127,7 @@ module aptos_framework::governed_gas_pool {
     /// Deposits gas fees into the governed gas pool.
     /// @param gas_payer The address of the account that paid the gas fees.
     /// @param gas_fee The amount of gas fees to be deposited.
-    public fun deposit_gas_fee(gas_payer: address, gas_fee: u64) acquires GovernedGasPool {
+    public (friend) fun deposit_gas_fee(gas_payer: address, gas_fee: u64) acquires GovernedGasPool {
         
         if (features::operations_default_to_fa_apt_store_enabled()) {
             deposit_from_fungible_store(gas_payer, gas_fee);

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -268,7 +268,7 @@ module aptos_framework::governed_gas_pool {
         let governed_gas_pool_balance = coin::balance<AptosCoin>(governed_gas_pool_address());
 
         // deposit some coin into the governed gas pool as gas fees
-        deposit_gas_fee(signer::address_of(depositor), 100);
+        deposit_gas_fee(aptos_framework, signer::address_of(depositor), 100);
 
         // check the balances after the deposit
         assert!(coin::balance<AptosCoin>(signer::address_of(depositor)) == depositor_balance - 100, 1);
@@ -311,7 +311,7 @@ module aptos_framework::governed_gas_pool {
         let governed_gas_pool_balance = coin::balance<AptosCoin>(governed_gas_pool_address());
 
         // collect gas fees from the depositor
-        deposit_gas_fee(signer::address_of(depositor), 100);
+        deposit_gas_fee(aptos_framework, signer::address_of(depositor), 100);
 
         // check the balances after the deposit
         assert!(coin::balance<AptosCoin>(signer::address_of(depositor)) == depositor_balance - 100, 1);

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -330,11 +330,11 @@ module aptos_framework::governed_gas_pool {
     
     }
 
-    #[test(not_aptos_framework = @0xdeadbeef, gas_payer = @0xdddd)]
+    #[test(aptos_framework = @aptos_framework, not_aptos_framework = @0xdeadbeef, gas_payer = @0xdddd)]
     #[expected_failure(abort_code = 327683, location = 0x1::system_addresses)] // EINVALID_SIGNER
-    fun test_deposit_gas_fee_invalid_signer(not_aptos_framework: &signer, gas_payer: &signer) acquires GovernedGasPool, AptosCoinMintCapability {
+    fun test_deposit_gas_fee_invalid_signer(aptos_framework: &signer, not_aptos_framework: &signer, gas_payer: &signer) acquires GovernedGasPool, AptosCoinMintCapability {
         // Initialize the modules
-        initialize_for_test(not_aptos_framework);
+        initialize_for_test(aptos_framework);
 
         // Create the gas payer account and fund it
         aptos_account::create_account(signer::address_of(gas_payer));

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -329,4 +329,24 @@ module aptos_framework::governed_gas_pool {
         assert!(coin::balance<AptosCoin>(signer::address_of(beneficiary)) == 100, 4);
     
     }
+
+    #[test(not_aptos_framework = @0xdeadbeef, gas_payer = @0xdddd)]
+    #[expected_failure(abort_code = 327683, location = 0x1::system_addresses)] // EINVALID_SIGNER
+    fun test_deposit_gas_fee_invalid_signer(not_aptos_framework: &signer, gas_payer: &signer) acquires GovernedGasPool, AptosCoinMintCapability {
+        // Initialize the modules
+        initialize_for_test(not_aptos_framework);
+
+        // Create the gas payer account and fund it
+        aptos_account::create_account(signer::address_of(gas_payer));
+        mint_for_test(signer::address_of(gas_payer), 1000);
+
+        // Get the balances for the gas payer and the governed gas pool
+        let gas_payer_balance = coin::balance<AptosCoin>(signer::address_of(gas_payer));
+        let governed_gas_pool_balance = coin::balance<AptosCoin>(governed_gas_pool_address());
+
+        // Attempt to deposit gas fees with an invalid signer
+        deposit_gas_fee(not_aptos_framework, signer::address_of(gas_payer), 100);
+
+        // No additional balance checks needed because the test is expected to fail
+    }
 }

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -127,7 +127,8 @@ module aptos_framework::governed_gas_pool {
     /// Deposits gas fees into the governed gas pool.
     /// @param gas_payer The address of the account that paid the gas fees.
     /// @param gas_fee The amount of gas fees to be deposited.
-    public (friend) fun deposit_gas_fee(gas_payer: address, gas_fee: u64) acquires GovernedGasPool {
+    public fun deposit_gas_fee(aptos_framework: &signer, gas_payer: address, gas_fee: u64) acquires GovernedGasPool {
+        system_addresses::assert_aptos_framework(aptos_framework);
         
         if (features::operations_default_to_fa_apt_store_enabled()) {
             deposit_from_fungible_store(gas_payer, gas_fee);

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.spec.move
@@ -68,7 +68,10 @@ spec aptos_framework::governed_gas_pool {
         //old(global<CoinStore<CoinType>>(aptos_framework_address).coin.value) + coin.value;
     }
 
-    spec deposit_gas_fee(gas_payer: address, gas_fee: u64) {
+    spec deposit_gas_fee(aptos_framework: &signer, gas_payer: address, gas_fee: u64) {
+        pragma aborts_if_is_partial = true;
+        aborts_if !system_addresses::is_aptos_framework_address(signer::address_of(aptos_framework));
+
         /// [high-level-req-5]
         //   ensures governed_gas_pool_balance<AptosCoin> == old(governed_gas_pool_balance<AptosCoin>) + gas_fee;
         //   ensures gas_payer_balance<AptosCoin> == old(gas_payer_balance<AptosCoin>) - gas_fee;

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -321,7 +321,7 @@ module aptos_framework::transaction_validation {
         if (amount_to_burn > storage_fee_refunded) {
             let burn_amount = amount_to_burn - storage_fee_refunded;
             if (features::governed_gas_pool_enabled()) {
-                governed_gas_pool::deposit_gas_fee(gas_payer, burn_amount);
+                governed_gas_pool::deposit_gas_fee(&account, gas_payer, burn_amount);
             } else {
                 transaction_fee::burn_fee(gas_payer, burn_amount);
             }

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -16,6 +16,7 @@ module aptos_framework::transaction_validation {
     use aptos_framework::governed_gas_pool;
 
     friend aptos_framework::genesis;
+    friend aptos_framework::governed_gas_pool;
 
     /// This holds information that will be picked up by the VM to call the
     /// correct chain-specific prologue and epilogue functions

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -16,7 +16,6 @@ module aptos_framework::transaction_validation {
     use aptos_framework::governed_gas_pool;
 
     friend aptos_framework::genesis;
-    friend aptos_framework::governed_gas_pool;
 
     /// This holds information that will be picked up by the VM to call the
     /// correct chain-specific prologue and epilogue functions


### PR DESCRIPTION
## Description
Fixed visibility of `deposit_gas_fee` by asserting caller is framework signer. 

Note that `(friend)` modifier fix did not work here because, this means that transaction validation module, which calls `deposit_gas_fee` must be a friend of ggp. Doing so creates a circular dependency cycle between transaction validation module and the ggp module. 

So instead, we just check that the signer of a `deposit_gas_fee` call is the framework signer and abort if not.

🟢 `movement move build`
🟢 `movement move test`

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
