### PR TITLE
Cleanup Move warnings in Governed Gas Pool module and spec

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/governed_gas_pool.md
@@ -212,6 +212,8 @@ Borrows the signer of the governed gas pool.
 
 ## Function `governed_gas_pool_address`
 
+Gets the address of the governed gas pool.
+@return The address of the governed gas pool.
 
 
 <pre><code>#[view]
@@ -380,7 +382,6 @@ Deposits gas fees into the governed gas pool.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_gas_fee">deposit_gas_fee</a>(gas_payer: <b>address</b>, gas_fee: u64) <b>acquires</b> <a href="governed_gas_pool.md#0x1_governed_gas_pool_GovernedGasPool">GovernedGasPool</a> {
-
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operations_default_to_fa_apt_store_enabled">features::operations_default_to_fa_apt_store_enabled</a>()) {
         <a href="governed_gas_pool.md#0x1_governed_gas_pool_deposit_from_fungible_store">deposit_from_fungible_store</a>(gas_payer, gas_fee);
     } <b>else</b> {
@@ -398,6 +399,8 @@ Deposits gas fees into the governed gas pool.
 
 ## Function `get_balance`
 
+Gets the balance of a specified coin type in the governed gas pool.
+@return The balance of the coin in the pool.
 
 
 <pre><code>#[view]

--- a/aptos-move/framework/aptos-framework/doc/native_bridge.md
+++ b/aptos-move/framework/aptos-framework/doc/native_bridge.md
@@ -340,8 +340,6 @@ A nonce to ensure the uniqueness of bridge transfers
 
 </details>
 
-<<<<<<< HEAD
-=======
 <a id="0x1_native_bridge_SmartTableWrapper"></a>
 
 ## Resource `SmartTableWrapper`
@@ -519,7 +517,6 @@ An event triggered upon change of bridgefee
 
 </details>
 
->>>>>>> movement
 <a id="@Constants_0"></a>
 
 ## Constants
@@ -1141,7 +1138,7 @@ Burns a specified amount of AptosCoin from an address.
 @abort If the burn capability is not available.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(core_resource: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, from: <b>address</b>, amount: u64)
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, from: <b>address</b>, amount: u64)
 </code></pre>
 
 
@@ -1150,8 +1147,8 @@ Burns a specified amount of AptosCoin from an address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(core_resource: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, from: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> {
-    <a href="system_addresses.md#0x1_system_addresses_assert_core_resource">system_addresses::assert_core_resource</a>(core_resource);
+<pre><code><b>public</b> entry <b>fun</b> <a href="native_bridge.md#0x1_native_bridge_burn_from">burn_from</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, from: <b>address</b>, amount: u64) <b>acquires</b> <a href="native_bridge.md#0x1_native_bridge_AptosCoinBurnCapability">AptosCoinBurnCapability</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <a href="native_bridge.md#0x1_native_bridge_burn_internal">burn_internal</a>(from, amount);
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.move
@@ -2,17 +2,20 @@ module aptos_framework::governed_gas_pool {
     use std::vector;
     use aptos_framework::account::{Self, SignerCapability, create_signer_with_capability};
     use aptos_framework::system_addresses::{Self};
-    use aptos_framework::primary_fungible_store::{Self};
+    // use aptos_framework::primary_fungible_store::{Self};
     use aptos_framework::fungible_asset::{Self};
     use aptos_framework::object::{Self};
-    use aptos_framework::aptos_coin::{Self, AptosCoin};
-    use aptos_framework::coin::{Self, Coin, MintCapability, BurnCapability};
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin::{Self, Coin};
     use std::features;
     use aptos_framework::signer;
-    use aptos_framework::aptos_account::{Self};
-
+    use aptos_framework::aptos_account::Self;
     #[test_only]
-    use aptos_framework::fungible_asset::{BurnRef};
+    use aptos_framework::coin::{BurnCapability, MintCapability};
+    #[test_only]
+    use aptos_framework::fungible_asset::BurnRef;
+    #[test_only]
+    use aptos_framework::aptos_coin::Self;
 
     const MODULE_SALT: vector<u8> = b"aptos_framework::governed_gas_pool";
 
@@ -69,9 +72,9 @@ module aptos_framework::governed_gas_pool {
         create_signer_with_capability(signer_cap)
     }
 
+    #[view]
     /// Gets the address of the governed gas pool.
     /// @return The address of the governed gas pool.
-    #[view]
     public fun governed_gas_pool_address(): address acquires GovernedGasPool {
         signer::address_of(&governed_gas_signer())
     }
@@ -128,7 +131,6 @@ module aptos_framework::governed_gas_pool {
     /// @param gas_payer The address of the account that paid the gas fees.
     /// @param gas_fee The amount of gas fees to be deposited.
     public fun deposit_gas_fee(gas_payer: address, gas_fee: u64) acquires GovernedGasPool {
-        
         if (features::operations_default_to_fa_apt_store_enabled()) {
             deposit_from_fungible_store(gas_payer, gas_fee);
         } else {
@@ -137,9 +139,9 @@ module aptos_framework::governed_gas_pool {
 
     }
 
+    #[view]
     /// Gets the balance of a specified coin type in the governed gas pool.
     /// @return The balance of the coin in the pool.
-    #[view]
     public fun get_balance<CoinType>(): u64 acquires GovernedGasPool {
         let pool_address = governed_gas_pool_address();
         coin::balance<CoinType>(pool_address)

--- a/aptos-move/framework/aptos-framework/sources/governed_gas_pool.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/governed_gas_pool.spec.move
@@ -1,5 +1,4 @@
 spec aptos_framework::governed_gas_pool {
-    use aptos_framework::coin::CoinStore; 
     use aptos_framework::coin::EINSUFFICIENT_BALANCE; 
     use aptos_framework::error;
 
@@ -55,6 +54,7 @@ spec aptos_framework::governed_gas_pool {
     spec deposit<CoinType>(coin: Coin<CoinType>) {
         pragma aborts_if_is_partial = true;
 
+        /*
         /// [high-level-req-3]
         /// Ensure the deposit increases the value in the CoinStore
 
@@ -66,11 +66,14 @@ spec aptos_framework::governed_gas_pool {
 
         //ensures global<CoinStore<CoinType>>(aptos_framework_address).coin.value ==
         //old(global<CoinStore<CoinType>>(aptos_framework_address).coin.value) + coin.value;
+        */
     }
 
     spec deposit_gas_fee(gas_payer: address, gas_fee: u64) {
+        /*
         /// [high-level-req-5]
         //   ensures governed_gas_pool_balance<AptosCoin> == old(governed_gas_pool_balance<AptosCoin>) + gas_fee;
         //   ensures gas_payer_balance<AptosCoin> == old(gas_payer_balance<AptosCoin>) - gas_fee;
+        */
     }
 }


### PR DESCRIPTION
## Description

- Clean up various Move warnings in `governed_gas_pool.move` and `governed_gas_pool.spec.move`

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

`movement move test`

## Key Areas to Review


## Checklist
- [x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ x] I have made corresponding changes to the documentation

## Outstanding issues:

In `aptos-move/e2e-move-tests`, `cargo test` fails with an unrelated error that also appears in the Aptos Labs `aptos-core` repo. Issue opened here: https://github.com/movementlabsxyz/aptos-core/issues/130
