### PR TITLE
fix: on `primary_fungible_store::transfer` create account if needed

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -15,6 +15,7 @@ module aptos_framework::primary_fungible_store {
     use aptos_framework::dispatchable_fungible_asset;
     use aptos_framework::fungible_asset::{Self, FungibleAsset, FungibleStore, Metadata, MintRef, TransferRef, BurnRef};
     use aptos_framework::object::{Self, Object, ConstructorRef, DeriveRef};
+    use aptos_framework::account;
 
     use std::option::Option;
     use std::signer;
@@ -182,6 +183,8 @@ module aptos_framework::primary_fungible_store {
         recipient: address,
         amount: u64,
     ) acquires DeriveRefPod {
+        // Create account if it does not yet exist, otherwise funds may get stuck in new accounts.
+        account::create_account_if_does_not_exist(recipient);
         let sender_store = ensure_primary_store_exists(signer::address_of(sender), metadata);
         // Check if the sender store object has been burnt or not. If so, unburn it first.
         may_be_unburn(sender, sender_store);

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -405,4 +405,28 @@ module aptos_framework::primary_fungible_store {
         assert!(balance(user_2_address, metadata) == 10, 0);
         deposit(user_2_address, coins);
     }
+
+    #[test(user_1 = @0xcafe, user_2 = @0xface)]
+    fun test_transfer_epilogue(user_1: &signer, user_2: &signer) acquires DeriveRefPod {
+        let (creator_ref, metadata) = create_test_token(user_1);
+        let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let user_1_address = signer::address_of(user_1);
+        let user_2_address = signer::address_of(user_2);
+
+        // Mint 100 tokens to user_1
+        mint(&mint_ref, user_1_address, 100);
+        assert!(balance(user_1_address, metadata) == 100, 1);
+        assert!(balance(user_2_address, metadata) == 0, 2);
+
+        // First transfer: user_1 to user_2
+        transfer(user_1, metadata, user_2_address, 50);
+        assert!(balance(user_1_address, metadata) == 50, 3);
+        assert!(balance(user_2_address, metadata) == 50, 4);
+
+        // Second transfer: user_1 to user_2
+        transfer(user_1, metadata, user_2_address, 30);
+        assert!(balance(user_1_address, metadata) == 20, 5);
+        assert!(balance(user_2_address, metadata) == 80, 6);
+    }
+
 }


### PR DESCRIPTION

## Description
- Issue #148 
- Call `account::create_account_if_does_not_exist` in `primary_fungible_store::transfer` to avoid funds being stuck in new accounts.
- Move unit tests all still pass.

## Type of Change
- [ ] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
- `aptos move test`

## Key Areas to Review
- This should be a pretty trivial change with no unwanted side effects, as it simply creates an account if one doesn't exist for the recipient.

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation